### PR TITLE
Add MVP phase plan (M0-M7) and GitHub milestones

### DIFF
--- a/docs/phases/milestones.json
+++ b/docs/phases/milestones.json
@@ -1,0 +1,10 @@
+{
+  "M0: Overlay skeleton": "phase:m0",
+  "M1: Character + interaction": "phase:m1",
+  "M2: Text-only loop": "phase:m2",
+  "M3: Voice on edge": "phase:m3",
+  "M4: Routing + remote slots": "phase:m4",
+  "M5: Notifications + actions": "phase:m5",
+  "M6: Context + profiling": "phase:m6",
+  "M7: Hardening + release": "phase:m7"
+}

--- a/docs/phases/phase-0-overlay-skeleton.md
+++ b/docs/phases/phase-0-overlay-skeleton.md
@@ -1,0 +1,48 @@
+# Phase 0: Overlay skeleton
+
+## Goal
+A foreground service starts, draws a static bubble overlay on top of other apps, and survives process death and reboot.
+
+## Spec references
+B1, B7
+
+## Deliverables
+
+### Overlay / UI surface
+- [ ] `ChampiService` foreground service with `foregroundServiceType="microphone|specialUse"` (`:app`)
+- [ ] `OverlayManager` — creates `WindowManager` overlay with `TYPE_APPLICATION_OVERLAY`, adds a static 56 dp placeholder bubble (`:overlay`)
+- [ ] `ComposeView` hosting with manually provided `LifecycleOwner`, `ViewModelStoreOwner`, `SavedStateRegistryOwner` (`:overlay`)
+- [ ] Persistent foreground notification so the service is not killed
+
+### Infrastructure
+- [ ] Gradle multi-module scaffold: `:app`, `:overlay`, `:character`, `:assistant`, `:providers:api`, `:providers:edge`, `:providers:remote`, `:audio`, `:actions`, `:context`, `:core`
+- [ ] Hilt/Dagger DI graph wired across modules
+- [ ] `SYSTEM_ALERT_WINDOW` permission request on first launch (basic — full onboarding flow deferred)
+- [ ] `POST_NOTIFICATIONS` runtime permission request (Android 13+)
+- [ ] `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_MICROPHONE`, `FOREGROUND_SERVICE_SPECIAL_USE` manifest declarations
+- [ ] Boot receiver to restart the service after reboot
+- [ ] CI: assembleDebug + lint on PRs
+- [ ] minSdk 29, targetSdk current
+
+## Done Definition
+- App installs on a minSdk 29 device/emulator
+- Granting overlay permission shows a static circular placeholder on top of the home screen and other apps
+- Killing the app via recents and reopening restores the overlay
+- Rebooting the device restarts the service and shows the overlay without manual launch
+- The foreground notification is visible in the system tray
+
+## Parallel work
+- None: this phase is the foundation all other work depends on
+
+## Phase dependencies
+- Requires: none
+
+## Complexity
+- Overlay/UI: M
+- Character: none
+- Assistant/Providers: none
+- Infra: L
+
+## Risks
+- OEM-specific battery optimization may kill the foreground service despite correct declarations (Xiaomi, Samsung, Huawei autostart restrictions)
+- `SYSTEM_ALERT_WINDOW` grant flow varies across OEMs; some redirect to an app list rather than a toggle

--- a/docs/phases/phase-1-character-interaction.md
+++ b/docs/phases/phase-1-character-interaction.md
@@ -1,0 +1,57 @@
+# Phase 1: Character + interaction
+
+## Goal
+The Rive mushroom character renders inside the bubble with idle animation, the bubble is draggable with edge-snap and dismiss, and tapping it expands an empty conversation panel.
+
+## Spec references
+B2, B3, B4, B5, B6, B7, B8, C1, C2, C3, C4, C5, P1
+
+## Deliverables
+
+### Overlay / UI surface
+- [ ] Touch handling: drag gesture on the bubble, edge-snap on release, position persistence via DataStore (`:overlay`)
+- [ ] Dismiss zone: drag to bottom-center hides the bubble until relaunch (`:overlay`)
+- [ ] Tap handler: single tap expands to a Compose bottom-sheet panel (~60% height), tap-outside or swipe-down collapses (`:overlay`)
+- [ ] Long-press quick-actions surface with the four actions: mute mic (no-op stub), push-to-talk (stub), sleep, settings (stub) (`:overlay`) — geometry decision (radial arc vs edge rail) must be made before this phase starts (open question 7)
+- [ ] IME avoidance: bubble auto-hides or repositions when the soft keyboard is open (`:overlay`)
+- [ ] Peek state: bubble tucks 28 dp under the snapped edge after N idle minutes (`:overlay`)
+
+### Character / rendering
+- [ ] Rive artboard `champi_mushroom` integration via `rive-android` (`:character`)
+- [ ] `AppState` to state-machine input bridge: maps `state`, `level`, `attention`, `mood` inputs (`:character`)
+- [ ] All seven `state` enum values wired: `idle`, `listening`, `thinking`, `speaking`, `notifying`, `error`, `sleeping` — idle animation active with breathing/blink/glance micro-motion (`:character`)
+- [ ] `attention` input driven by finger position during drag (`:character`)
+- [ ] Collapsed bubble (56 dp) and expanded avatar (96 dp) rendered from one artboard at two scales (`:character`)
+- [ ] Interruptible transitions: new state never waits for current animation to finish (`:character`)
+
+### Infrastructure
+- [ ] `AppState` StateFlow definition in `:core` — character state, conversation placeholder, audio placeholder
+- [ ] DataStore setup for bubble position and peek timing (`:core`)
+
+## Done Definition
+- Bubble renders the Rive mushroom with idle animation (breathing, blinking) over other apps
+- Dragging the bubble moves it; releasing snaps it to the nearest screen edge
+- Dragging to the bottom-center dismiss zone hides the bubble
+- Single-tapping the bubble opens an empty bottom-sheet panel; tapping outside collapses it
+- Long-pressing shows quick-action targets (visual only, actions are stubs)
+- The expanded panel header shows the 96 dp avatar rendered from the same artboard
+- After N idle minutes the bubble tucks under the edge (peek state)
+- Manually setting character state to each of the 7 values (via debug toggle or ADB) shows distinct visual treatment
+
+## Parallel work
+- `:character` Rive integration and `:overlay` touch/panel work can proceed in parallel once the `AppState` contract in `:core` is defined
+- Rive asset creation (art) is independent of code
+
+## Phase dependencies
+- Requires: Phase 0 (foreground service, overlay window, DI graph, module scaffold)
+
+## Complexity
+- Overlay/UI: L
+- Character: L
+- Assistant/Providers: none
+- Infra: S
+
+## Risks
+- Rive artboard with 7 states and 4 inputs needs to be authored or sourced — art pipeline could bottleneck
+- Touch handling on `WindowManager` overlays is tricky: distinguishing tap vs drag vs long-press without consuming touches meant for underlying apps
+- `ComposeView` inside an overlay has known issues with recomposition lifecycle on some Android versions

--- a/docs/phases/phase-2-text-loop.md
+++ b/docs/phases/phase-2-text-loop.md
@@ -1,0 +1,56 @@
+# Phase 2: Provider interfaces + text-only loop
+
+## Goal
+The user can type a message in the panel, an on-device LLM generates a streamed response, and the conversation persists across reopens.
+
+## Spec references
+P2, P3, P5, V4 (edge-only default)
+
+## Deliverables
+
+### Overlay / UI surface
+- [ ] Message list in the conversation panel: user turns right-aligned, champi turns left-aligned, streamed tokens (`:overlay`)
+- [ ] Input row: text field with send action (`:overlay`)
+- [ ] Character state driven by turn lifecycle: `idle` -> `thinking` -> `speaking` (text display) -> `idle` (`:overlay`)
+
+### Assistant / orchestration
+- [ ] `ConversationManager` — manages turns, appends user/assistant messages, persists to Room (`:assistant`)
+- [ ] `TurnOrchestrator` — receives user input, calls LLM provider, emits streamed tokens, updates `AppState` (`:assistant`)
+- [ ] Conversation persistence: Room database for messages, reopening the panel shows where you left off (`:assistant` + `:core`)
+
+### Providers
+- [ ] Provider interfaces in `:providers:api`: `LlmProvider`, `Provider` base, `Locality`, `Cost`, `ToolSpec`, `ToolCall`, `ToolResult`
+- [ ] Edge LLM provider implementation: small on-device model via llama.cpp JNI or MediaPipe LLM Inference (`:providers:edge`) — open question 2 must be resolved for runtime choice
+- [ ] Model download-on-first-use to app-private storage, with progress UI (`:providers:edge`)
+- [ ] Stub `SttProvider`, `TtsProvider`, `WakeWordProvider`, `VadProvider`, `ActionProvider` interfaces defined but not implemented (`:providers:api`)
+
+### Infrastructure
+- [ ] Room database schema: conversations, messages with role/content/timestamp/provider metadata (`:core`)
+- [ ] Model storage and versioning utilities (`:core`)
+
+## Done Definition
+- Typing a message and pressing send shows the user message in the panel
+- The character transitions to `thinking`, then streamed tokens appear as a champi response
+- The full response renders left-aligned once streaming completes, character returns to `idle`
+- Closing and reopening the panel (or killing the app) shows the prior conversation
+- The edge LLM model downloads on first use with visible progress
+- No network is required for the text loop to function
+
+## Parallel work
+- Provider interface design (`:providers:api`) can start as soon as Phase 1 freezes the `AppState` contract
+- Room schema work in `:core` is independent of LLM integration
+- Panel message-list UI can be built against fake data while the LLM provider is being integrated
+
+## Phase dependencies
+- Requires: Phase 1 (conversation panel shell, character state bridge, `AppState` StateFlow)
+
+## Complexity
+- Overlay/UI: M
+- Character: S
+- Assistant/Providers: XL
+- Infra: M
+
+## Risks
+- Edge LLM runtime choice (llama.cpp vs MediaPipe vs ExecuTorch) affects memory, latency, and model compatibility — needs early prototyping
+- On-device model memory footprint may exceed the 120 MB resident target on low-RAM devices
+- Model download size and first-use experience: users may abandon if the initial download is too large or slow

--- a/docs/phases/phase-3-voice-edge.md
+++ b/docs/phases/phase-3-voice-edge.md
@@ -1,0 +1,64 @@
+# Phase 3: Voice on edge
+
+## Goal
+The user can speak to champi via wake word or mic press, hear a spoken response from the on-device TTS, and interrupt playback with barge-in — all without network.
+
+## Spec references
+V1, V2, V3, V4, P3, P4, C2 (level input)
+
+## Deliverables
+
+### Overlay / UI surface
+- [ ] Mic button in input row: tap toggles listen mode, hold for push-to-talk (`:overlay`)
+- [ ] TTS stop button in panel header; visible during `speaking` state (`:overlay`)
+- [ ] Routing/locality footer line per turn (e.g. `whisper.cpp base -> local llm -> piper`) (`:overlay`)
+- [ ] Provider/locality tag in panel header (e.g. `edge . piper`) (`:overlay`)
+
+### Character / rendering
+- [ ] `level` input driven by mic amplitude during `listening` state (`:character`)
+- [ ] `level` input driven by TTS playback amplitude during `speaking` state (`:character`)
+
+### Assistant / orchestration
+- [ ] `VoiceTurnOrchestrator` — extends turn orchestration to handle audio input/output: wake -> VAD -> STT -> LLM -> TTS pipeline (`:assistant`)
+- [ ] Barge-in: user speech during TTS stops playback and starts a new turn (`:assistant`)
+- [ ] Per-turn routing metadata logged and surfaced to the panel footer (`:assistant`)
+
+### Providers
+- [ ] `WakeWordProvider` edge implementation: openWakeWord ONNX or Porcupine (`:providers:edge`) — open question 1
+- [ ] `VadProvider` edge implementation: Silero VAD (`:providers:edge`)
+- [ ] `SttProvider` edge implementation: whisper.cpp small/base or Android on-device `SpeechRecognizer` (`:providers:edge`) — open question 3
+- [ ] `TtsProvider` edge implementation: Android `TextToSpeech` or Piper (`:providers:edge`) — open question 4
+
+### Infrastructure
+- [ ] `:audio` module: `AudioCapture` (mic PCM stream), `PlaybackQueue` (TTS audio chunks), wake-word and VAD hosting
+- [ ] `RECORD_AUDIO` runtime permission request on first mic use
+- [ ] Android mic indicator compliance (V3): never suppress the system mic-use indicator
+- [ ] Model download for wake word, STT, TTS models (same storage/versioning infra from Phase 2)
+
+## Done Definition
+- Saying the wake word (or pressing the mic button) activates listening; the character transitions to `listening` with amplitude-driven ring
+- Speaking a query produces a transcription (visible in the panel), an LLM response, and spoken TTS output
+- During TTS playback the character shows `speaking` with amplitude-driven animation
+- Speaking during TTS playback interrupts it (barge-in) and starts a new listening turn
+- The Android system mic indicator is visible whenever the mic is active
+- Each turn's routing footer shows the provider chain used
+- The full voice loop works in airplane mode
+
+## Parallel work
+- Wake word + VAD work (`:audio` + `:providers:edge`) can proceed in parallel with STT/TTS provider implementation
+- Panel UI updates (mic button, footer, header tags) can be built in parallel with audio pipeline work
+
+## Phase dependencies
+- Requires: Phase 2 (provider interfaces, LLM provider, conversation persistence, turn orchestration)
+
+## Complexity
+- Overlay/UI: M
+- Character: S
+- Assistant/Providers: XL
+- Infra: L
+
+## Risks
+- Wake word accuracy: custom "hey champi" model needs training data and tuning for both es-MX and en-US
+- Audio pipeline latency: chaining wake -> VAD -> STT -> LLM -> TTS on-device must meet the 1.5 s p50 target
+- Simultaneous mic capture (wake word always-on) and TTS playback requires careful audio focus and echo management
+- Memory pressure: loading wake word + VAD + STT + LLM + TTS models concurrently may exceed 120 MB target

--- a/docs/phases/phase-4-routing-remote.md
+++ b/docs/phases/phase-4-routing-remote.md
@@ -1,0 +1,57 @@
+# Phase 4: Routing policy + remote provider slots
+
+## Goal
+The assistant selects edge or remote providers per turn based on a routing policy, supports an edge-only mode toggle, and queues turns when no provider is available.
+
+## Spec references
+P2 (routing footer explanation), P4 (remote badge), V4 (edge-only mode)
+
+## Deliverables
+
+### Overlay / UI surface
+- [ ] Remote badge in panel header when a turn is routed remote (`:overlay`)
+- [ ] Routing explanation variant in turn footer when edge LLM rejected a turn for size and sent it remote (`:overlay`)
+- [ ] Settings screen: provider pipeline view (STT/LLM/TTS rows with edge/remote tags, downloaded-model management), edge-only master toggle (`:app`) — settings structure decision (open question 9) must be made before this phase
+
+### Assistant / orchestration
+- [ ] `RoutingPolicy` implementation in `:assistant`: edge-first decision logic per the 4-step algorithm (user override -> edge available + fits -> remote available -> degrade)
+- [ ] "Fits" heuristic for LLM stage: input length, tool requirements, user rejection of prior edge answer (`:assistant`)
+- [ ] Routing decision logging for heuristic tuning (`:assistant`)
+- [ ] Turn queuing: when no provider is available, queue the turn and replay when connectivity/availability returns (`:assistant`)
+- [ ] Degraded mode: local intents only, character shows `error` briefly then `idle` (`:assistant`)
+
+### Providers
+- [ ] `SttProvider` remote stub (contract only, transport out of scope) (`:providers:remote`)
+- [ ] `LlmProvider` remote stub (`:providers:remote`)
+- [ ] `TtsProvider` remote stub (`:providers:remote`)
+- [ ] Provider `capabilities` reporting: languages, max input length, streaming support (`:providers:api`)
+- [ ] Provider `available()` implementation reflecting model load state and network reachability (`:providers:edge`, `:providers:remote`)
+
+### Infrastructure
+- [ ] DataStore settings for edge-only mode, per-provider enable/disable (`:core`)
+- [ ] Room schema for queued turns (`:core`)
+
+## Done Definition
+- With edge-only mode on, all turns route to edge providers regardless of input complexity
+- With edge-only mode off and a remote stub registered, a long/complex input shows the remote badge and routing explanation in the footer
+- When no provider is available (airplane mode + edge model unloaded), the turn is queued, character shows `error`, and the turn replays when a provider becomes available
+- Settings screen shows provider rows with edge/remote tags and the edge-only toggle
+- Routing decisions are logged and inspectable (via logcat or a debug screen)
+
+## Parallel work
+- Settings UI (`:app`) can be built in parallel with routing policy logic (`:assistant`)
+- Remote provider stubs (`:providers:remote`) are independent of routing policy implementation
+
+## Phase dependencies
+- Requires: Phase 3 (voice pipeline, all edge providers implemented, per-turn routing metadata)
+
+## Complexity
+- Overlay/UI: M
+- Character: none
+- Assistant/Providers: L
+- Infra: M
+
+## Risks
+- "Fits" heuristic thresholds (open question 5) are guesses initially; need real usage data to tune
+- Queued turn replay must handle stale context gracefully (conversation may have moved on)
+- Remote provider stubs are contracts only — actual transport is out of scope, so integration testing is limited to interface compliance

--- a/docs/phases/phase-5-notifications-actions.md
+++ b/docs/phases/phase-5-notifications-actions.md
@@ -1,0 +1,61 @@
+# Phase 5: Notifications + first device actions
+
+## Goal
+Champi can raise proactive notifications (with system tray mirroring and reply actions) and execute the first set of device actions: alarms, timers, and calendar events.
+
+## Spec references
+N1, N2, N3, P6 (notification action open), C2 (notifying state)
+
+## Deliverables
+
+### Overlay / UI surface
+- [ ] Notification action: tapping the notification opens the conversation panel (`:overlay`)
+- [ ] Action cards in message list: collapsed inline cards for running timers with undo affordance (`:overlay`)
+- [ ] Confirmation dialog for destructive actions (`:overlay`)
+
+### Character / rendering
+- [ ] `notifying` state activation: bubble pulses when a proactive notification is raised (`:character`)
+
+### Assistant / orchestration
+- [ ] Proactive notification engine: assistant layer raises notifications, classified as silent or urgent (`:assistant`)
+- [ ] Client-side rate limit on proactive interrupts, user-tunable (`:assistant`)
+- [ ] Tool-call flow: LLM emits `toolCall` events, orchestrator routes to `ActionProvider`, returns `ToolResult` (`:assistant`)
+
+### Providers
+- [ ] `ActionProvider` implementation for alarms and timers (`:actions`)
+- [ ] `ActionProvider` implementation for calendar events (`:actions`)
+- [ ] Per-action permission gating and toggle (`:actions`)
+- [ ] `ToolSpec` definitions for alarm/timer/calendar actions (`:actions`)
+
+### Infrastructure
+- [ ] System tray notification with reply actions (works when overlay is hidden or phone is locked) (`:app`)
+- [ ] `SCHEDULE_EXACT_ALARM` permission request on first alarm action (`:app`)
+- [ ] Quick Settings tile to open the panel (`:app`)
+- [ ] DataStore for per-action toggles and rate-limit settings (`:core`)
+
+## Done Definition
+- The assistant can proactively raise a notification; the bubble pulses and the system tray shows the notification with a reply action
+- Tapping the notification opens the conversation panel
+- Asking champi to set a timer creates a system alarm; the panel shows an inline timer card with undo
+- Asking champi to create a calendar event opens a pre-filled calendar intent or inserts directly (with confirmation)
+- Rate limiting is observable: after N proactive notifications in a window, further ones are suppressed
+- Actions respect per-action toggles in settings (disabled actions are refused gracefully)
+
+## Parallel work
+- Notification system (`:app` + `:assistant`) can be built in parallel with action providers (`:actions`)
+- Quick Settings tile is independent of both
+
+## Phase dependencies
+- Requires: Phase 2 (turn orchestration with tool-call flow, provider interfaces including `ActionProvider` and `ToolSpec`)
+- Requires: Phase 4 (routing policy, so tool calls route correctly)
+
+## Complexity
+- Overlay/UI: M
+- Character: S
+- Assistant/Providers: L
+- Infra: M
+
+## Risks
+- `SCHEDULE_EXACT_ALARM` restricted on Android 12+; some OEMs further restrict it
+- Proactive notification timing: too aggressive annoys users, too conservative makes the feature invisible
+- Calendar provider access varies across devices and accounts; some require additional permissions

--- a/docs/phases/phase-6-context-profiling.md
+++ b/docs/phases/phase-6-context-profiling.md
@@ -1,0 +1,59 @@
+# Phase 6: Share-sheet, camera, context + profiling
+
+## Goal
+Users can share content into champi from any app, capture images from the panel, opt in to periodic context, and the app meets its battery and latency targets.
+
+## Spec references
+P3 (attach: image, file, share-sheet payload), P6 (launcher icon open)
+
+## Deliverables
+
+### Overlay / UI surface
+- [ ] Attach button in input row: image picker, file picker, share-sheet payload display (`:overlay`)
+- [ ] Camera capture from the panel (`:overlay`)
+- [ ] Launcher icon opens the panel (`:app`)
+
+### Assistant / orchestration
+- [ ] Multi-modal turn support: images and files as conversation context alongside text (`:assistant`)
+
+### Providers
+- [ ] Share-sheet receiver: text, links, images, files routed into the current conversation (`:context`)
+- [ ] Optional periodic context provider: coarse location, battery, connectivity, foreground app name (`:context`)
+- [ ] Context opt-in settings: off by default, per-signal toggles (`:context`)
+
+### Infrastructure
+- [ ] `ACCESS_COARSE_LOCATION` permission request on enabling location context (`:app`)
+- [ ] `CAMERA` permission request on first camera use (`:app`)
+- [ ] Battery profiling: measure idle drain (overlay + wake word) against the 3% / 24h target (`:core`)
+- [ ] Latency profiling: measure end-of-speech to first TTS audio against 1.5 s p50 edge / 2.5 s p50 remote targets (`:core`)
+- [ ] Memory profiling: verify resident memory <= 120 MB with lazy model loading and memory-pressure unloading (`:core`)
+- [ ] Rive idle CPU verification: <= 2% CPU (`:character`)
+- [ ] Cold start measurement: bubble visible <= 800 ms (`:app`)
+
+## Done Definition
+- Sharing text/link/image from another app via the share sheet opens champi with the content in the conversation
+- Tapping the attach button allows picking an image or file; the content appears in the conversation
+- Camera capture from the panel attaches a photo to the current turn
+- Optional context (location, battery, etc.) is off by default; enabling it requests the appropriate permission and surfaces context in the assistant's input
+- Battery drain in idle (overlay + wake word active, screen off) is measured and documented against the 3% / 24h target
+- End-to-end voice latency is measured and documented against p50 targets
+- Resident memory with all edge models loaded is measured against the 120 MB target
+
+## Parallel work
+- Share-sheet receiver (`:context`) is independent of camera/attach UI (`:overlay`)
+- Profiling passes are independent of feature work and can run on any device fleet in parallel
+
+## Phase dependencies
+- Requires: Phase 3 (voice pipeline for latency profiling)
+- Requires: Phase 5 (full feature set active for realistic battery/memory profiling)
+
+## Complexity
+- Overlay/UI: M
+- Character: none
+- Assistant/Providers: M
+- Infra: L
+
+## Risks
+- Battery profiling results are device-dependent; meeting 3% / 24h on mid-range devices may require wake-word duty cycling or model unloading
+- Share-sheet intent handling across OEMs is inconsistent (MIME types, URI permissions, content provider access)
+- Camera capture inside an overlay window may conflict with other apps' camera use

--- a/docs/phases/phase-7-hardening-release.md
+++ b/docs/phases/phase-7-hardening-release.md
@@ -1,0 +1,62 @@
+# Phase 7: Hardening, localization, release
+
+## Goal
+The app is localized in es-MX and en-US, crash-free sessions reach 99.5%+, accessibility passes, and a self-hosted APK release channel is operational.
+
+## Spec references
+B6 (DND schedule), P6 (all entry points), V1 (onboarding privacy copy), V4 (mute schedule)
+
+## Deliverables
+
+### Overlay / UI surface
+- [ ] Onboarding flow (checklist or stepper per open question 8 decision) with privacy disclosure: wake word and VAD stay on-device, audio only leaves device after wake/press and only if remote provider is enabled (`:app`)
+- [ ] Full settings screen: voice settings (wake word on/off, push-to-talk only, mute schedule, earcons), provider management, action toggles, bubble peek timing, proactive-interrupt rate limit (`:app`)
+- [ ] DND schedule: bubble auto-hides and wake word suspends during configured quiet hours (`:overlay`)
+- [ ] TalkBack labels on bubble, panel, quick actions, and all interactive elements (`:overlay`)
+- [ ] Panel fully usable without voice (text-only path with keyboard) (`:overlay`)
+
+### Character / rendering
+- [ ] `sleeping` state visual treatment activated by DND schedule or sleep quick action (`:character`)
+- [ ] Earcons: optional sounds on wake and end-of-turn, off by default (`:audio`)
+
+### Assistant / orchestration
+- [ ] Conversation memory management: context windowing for edge vs remote LLM (`:assistant`) — open question 6 informs scope
+
+### Infrastructure
+- [ ] es-MX and en-US string localization for all UI copy (all modules)
+- [ ] Crash reporting and crash-free session tracking (`:app`)
+- [ ] Crash-free sessions target: >= 99.5%
+- [ ] `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` prompt: shown only after the service has been killed once (`:app`)
+- [ ] OEM autostart quirk documentation and in-app guidance (`:app`)
+- [ ] Self-hosted APK release channel: signed builds, update check mechanism (`:app`)
+- [ ] Edge model lifecycle: models deletable from settings, versioned, lazy-loaded, unloaded on memory pressure (`:providers:edge`)
+- [ ] No third-party analytics; no audio retained beyond the streaming buffer (privacy compliance) (all modules)
+
+## Done Definition
+- The app is fully usable in both es-MX and en-US; switching device language updates all UI strings
+- Onboarding flow grants required permissions and displays the privacy disclosure before the service starts
+- TalkBack can navigate and activate every interactive element (bubble, panel, quick actions, settings)
+- DND schedule hides the bubble and suspends wake word during quiet hours; character shows `sleeping`
+- Crash-free session rate is >= 99.5% over a multi-day dogfood period
+- A signed APK is downloadable from the self-hosted channel and installs cleanly on a fresh device
+- The app checks for updates from the self-hosted channel
+
+## Parallel work
+- Localization (string extraction + translation) can run in parallel with crash hardening
+- Accessibility audit and fixes can run in parallel with release infrastructure
+- Self-hosted release channel setup is independent of all feature work
+
+## Phase dependencies
+- Requires: Phase 6 (all features complete, profiling done, performance budgets met or documented)
+
+## Complexity
+- Overlay/UI: L
+- Character: S
+- Assistant/Providers: M
+- Infra: L
+
+## Risks
+- Achieving 99.5% crash-free on the diversity of Android 10+ devices requires broad testing
+- OEM autostart/battery quirks are a long tail; documentation helps but cannot solve all devices
+- Self-hosted update mechanism must handle signature verification and downgrade protection
+- Localization of LLM-generated content depends on model capabilities, not just UI strings


### PR DESCRIPTION
## Summary
- Adds docs/phases/phase-0..7-*.md: full phase docs expanding the spec's M0-M7 milestone table (goal, deliverables by module, done definition, parallel work, dependencies, complexity, risks)
- Adds docs/phases/milestones.json mapping milestone titles to phase labels
- Creates the 8 matching GitHub Milestones and phase:m0-m7 labels

## Test plan
- [ ] Review phase sequencing and parallelism notes
- [ ] Confirm milestone titles match milestones.json exactly