### PR TITLE
Thin-client redesign doc, data-flow figures, and round 1 / round 2 issue split

### DIFF
--- a/docs/design/figures/01-before-after.svg
+++ b/docs/design/figures/01-before-after.svg
@@ -1,0 +1,116 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" role="img" aria-label="Left: spec v0.3 phone holds wake word, VAD, STT, LLM, TTS, routing policy and memory, with remote providers as an unavailable stub. Right: redesigned phone holds wake word, VAD, Rive bubble and tray, linked by one WebSocket to a brain holding gateway, STT, Claude, TTS, memory, rc-mcp tools and monitors.">
+        
+<style>
+  svg { color:#161413; font-family: Archivo, "Helvetica Neue", Arial, sans-serif; }
+  .box { fill:#ffffff; stroke:currentColor; stroke-width:1.4; }
+  .box.srv { fill:#e6e9ec; }
+  .box.ghost { fill:none; stroke:#6f6a67; stroke-dasharray:4 4; }
+  .box.hotline { stroke:#ec3013; stroke-width:2; }
+  .col { fill:none; stroke:#d6d1ce; stroke-width:1.5; }
+  .col.srv { fill:#e6e9ec; fill-opacity:0.45; }
+  .t { font-size:12.5px; font-weight:600; fill:currentColor; }
+  .s { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:10.5px; fill:#6f6a67; }
+  .hd { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:11px; letter-spacing:0.08em; fill:#6f6a67; }
+  .tag { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:10.5px; fill:#ec3013; }
+  .lbl { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:11px; fill:currentColor; }
+  .lbl.m { fill:#6f6a67; }
+  .lbl.hot { fill:#ec3013; font-weight:500; }
+  .bar { fill:#ffffff; stroke:currentColor; stroke-width:1.2; }
+  .bar.hot { stroke:#ec3013; stroke-width:1.8; }
+  .bt { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:10px; fill:currentColor; }
+  .lane { stroke:#d6d1ce; stroke-width:1.5; }
+  .ln { stroke:currentColor; stroke-width:1.4; fill:none; }
+  .ln.d { stroke-dasharray:4 3; }
+  .ln.hot { stroke:#ec3013; stroke-width:2.4; }
+  .ln.hotd { stroke:#ec3013; stroke-width:1.6; stroke-dasharray:5 4; }
+  .halo { stroke:#f3f2f2; stroke-width:7; fill:none; }
+  .arr polygon { fill:currentColor; }
+  .arrhot polygon { fill:#ec3013; }
+  .arrm polygon { fill:#6f6a67; }
+</style>
+<defs>
+          <marker id="arr1" class="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+          <marker id="arr1m" class="arrm" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+          <marker id="arr1h" class="arrhot" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+        </defs><rect width="960" height="400" fill="#f3f2f2"/>
+
+        <!-- LEFT: spec -->
+        <text class="hd" x="10" y="24">SPEC v0.3 · EDGE-FIRST</text>
+        <rect class="col" x="10" y="40" width="240" height="340"/>
+        <text class="s" x="26" y="60">Phone · everything on device</text>
+
+        <rect class="box" x="26" y="70" width="208" height="34"/>
+        <text class="t" x="36" y="92">Wake word</text>
+        <text class="s" x="226" y="92" text-anchor="end">stays</text>
+
+        <rect class="box" x="26" y="112" width="208" height="34"/>
+        <text class="t" x="36" y="134">VAD</text>
+        <text class="s" x="226" y="134" text-anchor="end">stays</text>
+
+        <rect class="box" x="26" y="154" width="208" height="34"/>
+        <text class="t" x="36" y="176">STT · whisper.cpp</text>
+        <text class="tag" x="226" y="176" text-anchor="end">→ brain</text>
+
+        <rect class="box" x="26" y="196" width="208" height="34"/>
+        <text class="t" x="36" y="218">LLM · on-device model</text>
+        <text class="tag" x="226" y="218" text-anchor="end">→ brain</text>
+
+        <rect class="box" x="26" y="238" width="208" height="34"/>
+        <text class="t" x="36" y="260">TTS · Piper</text>
+        <text class="tag" x="226" y="260" text-anchor="end">→ brain</text>
+
+        <rect class="box" x="26" y="280" width="208" height="34"/>
+        <text class="t" x="36" y="302">Routing policy · queue</text>
+        <text class="tag" x="226" y="302" text-anchor="end">removed</text>
+
+        <rect class="box" x="26" y="322" width="208" height="34"/>
+        <text class="t" x="36" y="344">Memory · context</text>
+        <text class="tag" x="226" y="344" text-anchor="end">→ brain</text>
+
+        <rect class="box ghost" x="290" y="150" width="190" height="110"/>
+        <text class="t" x="304" y="176">Remote providers</text>
+        <text class="s" x="304" y="196">stub · available() = false</text>
+        <text class="s" x="304" y="212">transport: out of scope</text>
+        <text class="s" x="304" y="228">never reached in v1</text>
+        <line class="ln d" x1="234" y1="213" x2="290" y2="205" marker-end="url(#arr1m)" stroke="#6f6a67"/>
+
+        <!-- RIGHT: redesign -->
+        <text class="hd" x="500" y="24">REDESIGN · THIN CLIENT</text>
+        <rect class="col" x="500" y="40" width="180" height="340"/>
+        <text class="s" x="516" y="60">Phone · ears and face</text>
+
+        <rect class="box" x="516" y="70" width="148" height="34"/>
+        <text class="t" x="526" y="92">Wake word</text>
+        <rect class="box" x="516" y="112" width="148" height="34"/>
+        <text class="t" x="526" y="134">VAD</text>
+        <rect class="box" x="516" y="154" width="148" height="34"/>
+        <text class="t" x="526" y="176">Rive bubble · panel</text>
+        <rect class="box" x="516" y="196" width="148" height="34"/>
+        <text class="t" x="526" y="218">Tray · share sheet</text>
+        <text class="s" x="516" y="352">no models</text>
+        <text class="s" x="516" y="366">no routing · no LLM</text>
+
+        <rect class="col srv" x="780" y="40" width="170" height="340"/>
+        <text class="s" x="796" y="60">Brain · your server</text>
+
+        <rect class="box hotline" x="796" y="70" width="138" height="34"/>
+        <text class="t" x="806" y="92">Gateway · WS</text>
+        <rect class="box" x="796" y="112" width="138" height="34"/>
+        <text class="t" x="806" y="134">STT · champi-stt</text>
+        <rect class="box" x="796" y="154" width="138" height="34"/>
+        <text class="t" x="806" y="176">LLM · Claude</text>
+        <rect class="box" x="796" y="196" width="138" height="34"/>
+        <text class="t" x="806" y="218">TTS · champi-tts</text>
+        <rect class="box" x="796" y="238" width="138" height="34"/>
+        <text class="t" x="806" y="260">Memory</text>
+        <rect class="box" x="796" y="280" width="138" height="34"/>
+        <text class="t" x="806" y="302">Tools · rc-mcp</text>
+        <rect class="box" x="796" y="322" width="138" height="34"/>
+        <text class="t" x="806" y="344">Monitors</text>
+
+        <line class="ln hot" x1="680" y1="87" x2="780" y2="87" marker-start="url(#arr1h)" marker-end="url(#arr1h)"/>
+        <text class="lbl hot" x="730" y="70" text-anchor="middle">WebSocket</text>
+        <text class="lbl" x="730" y="108" text-anchor="middle">→ PCM · text</text>
+        <text class="lbl" x="730" y="122" text-anchor="middle">← audio · text</text>
+        <text class="lbl m" x="730" y="140" text-anchor="middle">Tailscale</text>
+      </svg>

--- a/docs/design/figures/02-data-flow.svg
+++ b/docs/design/figures/02-data-flow.svg
@@ -1,0 +1,158 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 470" role="img" aria-label="Three columns. Phone column with bubble, wake word and VAD, local cache, notification tray, share sheet. Brain column with gateway, agent loop, memory, scheduler. Infrastructure column with champi-stt, champi-tts, Claude API, rc-mcp, and GPUs, docker, services. Red arrows carry PCM, text and files from phone to gateway and audio, tokens and notifications back. Gateway exchanges PCM and transcripts with champi-stt, sentences and audio chunks with champi-tts. Agent loop exchanges prompts and tokens with Claude API and sends MCP tool calls to rc-mcp, whose agents reach GPUs, docker and services.">
+        
+<style>
+  svg { color:#161413; font-family: Archivo, "Helvetica Neue", Arial, sans-serif; }
+  .box { fill:#ffffff; stroke:currentColor; stroke-width:1.4; }
+  .box.srv { fill:#e6e9ec; }
+  .box.ghost { fill:none; stroke:#6f6a67; stroke-dasharray:4 4; }
+  .box.hotline { stroke:#ec3013; stroke-width:2; }
+  .col { fill:none; stroke:#d6d1ce; stroke-width:1.5; }
+  .col.srv { fill:#e6e9ec; fill-opacity:0.45; }
+  .t { font-size:12.5px; font-weight:600; fill:currentColor; }
+  .s { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:10.5px; fill:#6f6a67; }
+  .hd { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:11px; letter-spacing:0.08em; fill:#6f6a67; }
+  .tag { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:10.5px; fill:#ec3013; }
+  .lbl { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:11px; fill:currentColor; }
+  .lbl.m { fill:#6f6a67; }
+  .lbl.hot { fill:#ec3013; font-weight:500; }
+  .bar { fill:#ffffff; stroke:currentColor; stroke-width:1.2; }
+  .bar.hot { stroke:#ec3013; stroke-width:1.8; }
+  .bt { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:10px; fill:currentColor; }
+  .lane { stroke:#d6d1ce; stroke-width:1.5; }
+  .ln { stroke:currentColor; stroke-width:1.4; fill:none; }
+  .ln.d { stroke-dasharray:4 3; }
+  .ln.hot { stroke:#ec3013; stroke-width:2.4; }
+  .ln.hotd { stroke:#ec3013; stroke-width:1.6; stroke-dasharray:5 4; }
+  .halo { stroke:#f3f2f2; stroke-width:7; fill:none; }
+  .arr polygon { fill:currentColor; }
+  .arrhot polygon { fill:#ec3013; }
+  .arrm polygon { fill:#6f6a67; }
+</style>
+<defs>
+          <marker id="arr2" class="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+          <marker id="arr2h" class="arrhot" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+        </defs><rect width="960" height="470" fill="#f3f2f2"/>
+
+        <text class="hd" x="20" y="24">PHONE</text>
+        <text class="hd" x="360" y="24">BRAIN · YOUR SERVER</text>
+        <text class="hd" x="720" y="24">YOUR INFRASTRUCTURE</text>
+
+        <rect class="col" x="20" y="36" width="220" height="414"/>
+        <rect class="col srv" x="360" y="36" width="240" height="414"/>
+        <rect class="col srv" x="720" y="36" width="220" height="414"/>
+
+        <!-- Phone boxes -->
+        <rect class="box" x="36" y="60" width="188" height="44"/>
+        <text class="t" x="46" y="78">Bubble · panel</text>
+        <text class="s" x="46" y="94">Rive · Compose · state</text>
+        <text class="tag" x="214" y="78" text-anchor="end">◀ tokens</text>
+
+        <rect class="box" x="36" y="124" width="188" height="44"/>
+        <text class="t" x="46" y="142">Wake word · VAD</text>
+        <text class="s" x="46" y="158">on device · always on</text>
+        <text class="tag" x="214" y="142" text-anchor="end">PCM ▶</text>
+
+        <rect class="box" x="36" y="188" width="188" height="44"/>
+        <text class="t" x="46" y="206">Local cache</text>
+        <text class="s" x="46" y="222">Room transcript · DataStore</text>
+
+        <rect class="box" x="36" y="252" width="188" height="44"/>
+        <text class="t" x="46" y="270">Notification tray</text>
+        <text class="s" x="46" y="286">reply from lock screen</text>
+        <text class="tag" x="214" y="270" text-anchor="end">◀ push</text>
+
+        <rect class="box" x="36" y="316" width="188" height="44"/>
+        <text class="t" x="46" y="334">Share sheet</text>
+        <text class="s" x="46" y="350">idea inbox from any app</text>
+        <text class="tag" x="214" y="334" text-anchor="end">idea ▶</text>
+
+        <text class="s" x="36" y="438">brain client · one WebSocket</text>
+
+        <!-- Brain boxes -->
+        <rect class="box hotline" x="376" y="60" width="208" height="172"/>
+        <text class="t" x="386" y="80">Gateway</text>
+        <text class="s" x="386" y="96">auth · WS · stream broker</text>
+        <text class="s" x="386" y="128">· one session per phone</text>
+        <text class="s" x="386" y="144">· PCM ↔ champi-stt</text>
+        <text class="s" x="386" y="160">· sentences ↔ champi-tts</text>
+        <text class="s" x="386" y="176">· tokens and pushes ↓ phone</text>
+        <text class="s" x="386" y="192">· share items → agent loop</text>
+
+        <rect class="box" x="376" y="252" width="208" height="44"/>
+        <text class="t" x="386" y="270">Agent loop</text>
+        <text class="s" x="386" y="286">Claude · tools · confirmations</text>
+
+        <rect class="box" x="376" y="316" width="100" height="44"/>
+        <text class="t" x="386" y="334">Memory</text>
+        <text class="s" x="386" y="350">ideas · notes</text>
+
+        <rect class="box" x="484" y="316" width="100" height="44"/>
+        <text class="t" x="494" y="334">Scheduler</text>
+        <text class="s" x="494" y="350">cron checks</text>
+
+        <text class="s" x="376" y="438">python · champi-ipc · champi-signals</text>
+
+        <!-- Infra boxes -->
+        <rect class="box" x="736" y="124" width="188" height="44"/>
+        <text class="t" x="746" y="142">champi-stt</text>
+        <text class="s" x="746" y="158">Whisper on GPU · streaming</text>
+
+        <rect class="box" x="736" y="188" width="188" height="44"/>
+        <text class="t" x="746" y="206">champi-tts</text>
+        <text class="s" x="746" y="222">Kokoro on GPU · streaming</text>
+
+        <rect class="box" x="736" y="252" width="188" height="44"/>
+        <text class="t" x="746" y="270">Claude API</text>
+        <text class="s" x="746" y="286">Opus 5 · Sonnet 5 monitors</text>
+
+        <rect class="box" x="736" y="316" width="188" height="44"/>
+        <text class="t" x="746" y="334">rc-mcp</text>
+        <text class="s" x="746" y="350">server + agent per machine</text>
+
+        <rect class="box" x="736" y="380" width="188" height="44"/>
+        <text class="t" x="746" y="398">GPUs · docker · services</text>
+        <text class="s" x="746" y="414">shell · files · procs</text>
+
+        <text class="s" x="736" y="438">Tailscale · nothing public</text>
+
+        <!-- Phone <-> Gateway (hot) -->
+        <line class="ln hot" x1="240" y1="140" x2="376" y2="140" marker-end="url(#arr2h)"/>
+        <text class="lbl hot" x="308" y="133" text-anchor="middle">PCM · text · files</text>
+        <line class="ln hot" x1="376" y1="162" x2="240" y2="162" marker-end="url(#arr2h)"/>
+        <text class="lbl hot" x="308" y="178" text-anchor="middle">audio · tokens</text>
+        <text class="lbl hot" x="308" y="191" text-anchor="middle">notifications</text>
+
+        <!-- Gateway <-> STT -->
+        <line class="ln" x1="584" y1="140" x2="736" y2="140" marker-end="url(#arr2)"/>
+        <text class="lbl" x="660" y="133" text-anchor="middle">PCM stream</text>
+        <line class="ln" x1="736" y1="162" x2="584" y2="162" marker-end="url(#arr2)"/>
+        <text class="lbl" x="660" y="178" text-anchor="middle">transcripts</text>
+
+        <!-- Gateway <-> TTS -->
+        <line class="ln" x1="584" y1="204" x2="736" y2="204" marker-end="url(#arr2)"/>
+        <text class="lbl" x="660" y="197" text-anchor="middle">sentences</text>
+        <line class="ln" x1="736" y1="226" x2="584" y2="226" marker-end="url(#arr2)"/>
+        <text class="lbl" x="660" y="240" text-anchor="middle">audio chunks</text>
+
+        <!-- Gateway <-> Agent loop -->
+        <line class="ln" x1="470" y1="232" x2="470" y2="252" marker-end="url(#arr2)"/>
+        <line class="ln" x1="490" y1="252" x2="490" y2="232" marker-end="url(#arr2)"/>
+        <text class="lbl" x="500" y="246">text ↓ tokens ↑</text>
+
+        <!-- Agent loop <-> Claude API -->
+        <line class="ln" x1="584" y1="272" x2="736" y2="272" marker-start="url(#arr2)" marker-end="url(#arr2)"/>
+        <text class="lbl" x="660" y="265" text-anchor="middle">messages ↔ tokens</text>
+
+        <!-- Agent loop -> rc-mcp (orthogonal) -->
+        <polyline class="ln" points="584,292 650,292 650,338 736,338" marker-end="url(#arr2)"/>
+        <text class="lbl" x="656" y="326">MCP tools</text>
+
+        <!-- rc-mcp -> machines -->
+        <line class="ln" x1="830" y1="360" x2="830" y2="380" marker-end="url(#arr2)"/>
+        <text class="lbl m" x="838" y="374">agents</text>
+
+        <!-- Memory / Scheduler <-> Agent loop -->
+        <line class="ln" x1="426" y1="316" x2="426" y2="296" marker-start="url(#arr2)" marker-end="url(#arr2)"/>
+        <line class="ln" x1="534" y1="316" x2="534" y2="296" marker-end="url(#arr2)"/>
+        <text class="lbl m" x="542" y="310">wakes</text>
+      </svg>

--- a/docs/design/figures/03-voice-turn.svg
+++ b/docs/design/figures/03-voice-turn.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 344" role="img" aria-label="Timeline with five lanes: phone, gateway, STT, Claude, TTS. Wake word on the phone starts PCM streaming to gateway and STT. STT returns partials then a final transcript to Claude. Claude streams tokens to TTS and to the phone. TTS returns audio which the phone plays. When the user speaks over playback, barge-in cancels TTS, tokens and playback and the phone is listening again. Target from end of speech to first audio is 1.5 seconds.">
+        
+<style>
+  svg { color:#161413; font-family: Archivo, "Helvetica Neue", Arial, sans-serif; }
+  .box { fill:#ffffff; stroke:currentColor; stroke-width:1.4; }
+  .box.srv { fill:#e6e9ec; }
+  .box.ghost { fill:none; stroke:#6f6a67; stroke-dasharray:4 4; }
+  .box.hotline { stroke:#ec3013; stroke-width:2; }
+  .col { fill:none; stroke:#d6d1ce; stroke-width:1.5; }
+  .col.srv { fill:#e6e9ec; fill-opacity:0.45; }
+  .t { font-size:12.5px; font-weight:600; fill:currentColor; }
+  .s { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:10.5px; fill:#6f6a67; }
+  .hd { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:11px; letter-spacing:0.08em; fill:#6f6a67; }
+  .tag { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:10.5px; fill:#ec3013; }
+  .lbl { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:11px; fill:currentColor; }
+  .lbl.m { fill:#6f6a67; }
+  .lbl.hot { fill:#ec3013; font-weight:500; }
+  .bar { fill:#ffffff; stroke:currentColor; stroke-width:1.2; }
+  .bar.hot { stroke:#ec3013; stroke-width:1.8; }
+  .bt { font-family:"IBM Plex Mono",Menlo,Consolas,monospace; font-size:10px; fill:currentColor; }
+  .lane { stroke:#d6d1ce; stroke-width:1.5; }
+  .ln { stroke:currentColor; stroke-width:1.4; fill:none; }
+  .ln.d { stroke-dasharray:4 3; }
+  .ln.hot { stroke:#ec3013; stroke-width:2.4; }
+  .ln.hotd { stroke:#ec3013; stroke-width:1.6; stroke-dasharray:5 4; }
+  .halo { stroke:#f3f2f2; stroke-width:7; fill:none; }
+  .arr polygon { fill:currentColor; }
+  .arrhot polygon { fill:#ec3013; }
+  .arrm polygon { fill:#6f6a67; }
+</style>
+<defs>
+          <marker id="arr3" class="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+        </defs><rect width="960" height="344" fill="#f3f2f2"/>
+
+        <text class="lbl m" x="940" y="32" text-anchor="end">not to scale</text>
+
+        <!-- lanes -->
+        <text class="t" x="112" y="60" text-anchor="end">Phone</text>
+        <text class="t" x="112" y="110" text-anchor="end">Gateway</text>
+        <text class="t" x="112" y="160" text-anchor="end">STT · GPU</text>
+        <text class="t" x="112" y="210" text-anchor="end">Claude</text>
+        <text class="t" x="112" y="260" text-anchor="end">TTS · GPU</text>
+        <line class="lane" x1="124" y1="56" x2="940" y2="56"/>
+        <line class="lane" x1="124" y1="106" x2="940" y2="106"/>
+        <line class="lane" x1="124" y1="156" x2="940" y2="156"/>
+        <line class="lane" x1="124" y1="206" x2="940" y2="206"/>
+        <line class="lane" x1="124" y1="256" x2="940" y2="256"/>
+
+        <!-- Phone bars -->
+        <rect class="bar" x="124" y="45" width="106" height="22"/>
+        <text class="bt" x="130" y="60">idle · wake word</text>
+        <rect class="bar" x="230" y="45" width="190" height="22"/>
+        <text class="bt" x="236" y="60">LISTENING · streams PCM</text>
+        <rect class="bar" x="560" y="45" width="100" height="22"/>
+        <text class="bt" x="566" y="60">SPEAKING · play</text>
+        <rect class="bar hot" x="660" y="45" width="120" height="22"/>
+        <text class="bt" x="666" y="60">LISTENING again</text>
+
+        <!-- wake tick + label -->
+        <line class="ln hot" x1="230" y1="38" x2="230" y2="74"/>
+        <text class="lbl hot" x="234" y="34">wake · ≤150 ms to LISTENING</text>
+        <!-- end of speech tick -->
+        <line class="ln" x1="420" y1="40" x2="420" y2="72" stroke="#6f6a67"/>
+        <text class="lbl m" x="424" y="34">VAD: end of speech</text>
+
+        <!-- Gateway bars -->
+        <rect class="bar" x="236" y="95" width="190" height="22"/>
+        <text class="bt" x="242" y="110">PCM → STT · partials ↑</text>
+        <rect class="bar" x="520" y="95" width="140" height="22"/>
+        <text class="bt" x="526" y="110">tokens + audio → phone</text>
+
+        <!-- STT bar -->
+        <rect class="bar" x="246" y="145" width="190" height="22"/>
+        <text class="bt" x="252" y="160">Whisper streaming · partials</text>
+
+        <!-- Claude bar -->
+        <rect class="bar" x="446" y="195" width="214" height="22"/>
+        <text class="bt" x="452" y="210">Opus 5 · streams tokens</text>
+
+        <!-- TTS bar -->
+        <rect class="bar" x="476" y="245" width="184" height="22"/>
+        <text class="bt" x="482" y="260">Kokoro · sentence → audio</text>
+
+        <!-- arrows -->
+        <line class="ln" x1="300" y1="67" x2="300" y2="95" marker-end="url(#arr3)"/>
+        <text class="lbl" x="305" y="85">PCM</text>
+        <line class="ln" x1="310" y1="117" x2="310" y2="145" marker-end="url(#arr3)"/>
+
+        <line class="ln d" x1="380" y1="145" x2="380" y2="117" marker-end="url(#arr3)"/>
+        <line class="ln d" x1="380" y1="95" x2="380" y2="67" marker-end="url(#arr3)"/>
+        <text class="lbl" x="385" y="85">partials</text>
+
+        <line class="ln" x1="440" y1="160" x2="440" y2="195" marker-end="url(#arr3)"/>
+        <text class="lbl" x="445" y="186">final text</text>
+
+        <line class="ln" x1="480" y1="217" x2="480" y2="245" marker-end="url(#arr3)"/>
+        <text class="lbl" x="485" y="236">sentences</text>
+
+        <line class="ln d" x1="530" y1="195" x2="530" y2="117" marker-end="url(#arr3)"/>
+        <text class="lbl" x="525" y="140" text-anchor="end">tokens</text>
+        <line class="ln d" x1="530" y1="95" x2="530" y2="67" marker-end="url(#arr3)"/>
+
+        <line class="halo" x1="560" y1="245" x2="560" y2="117"/>
+        <line class="ln" x1="560" y1="245" x2="560" y2="117" marker-end="url(#arr3)"/>
+        <text class="lbl" x="565" y="236">first audio</text>
+        <line class="ln" x1="560" y1="95" x2="560" y2="67" marker-end="url(#arr3)"/>
+
+        <!-- barge-in -->
+        <line class="ln hotd" x1="660" y1="40" x2="660" y2="276"/>
+        <text class="lbl hot" x="660" y="296" text-anchor="middle">barge-in · user speaks over playback → cancel TTS, tokens, playback → LISTENING</text>
+
+        <!-- latency bracket -->
+        <line class="ln" x1="420" y1="314" x2="560" y2="314" stroke="#6f6a67"/>
+        <line class="ln" x1="420" y1="309" x2="420" y2="319" stroke="#6f6a67"/>
+        <line class="ln" x1="560" y1="309" x2="560" y2="319" stroke="#6f6a67"/>
+        <text class="lbl m" x="490" y="334" text-anchor="middle">end of speech → first audio · target ≤ 1.5 s over LAN with GPU STT and TTS</text>
+      </svg>

--- a/docs/design/thin-client.html
+++ b/docs/design/thin-client.html
@@ -1,0 +1,576 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Champi Thin Client</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap">
+<style>
+  :root {
+    --bg: #f3f2f2;
+    --ink: #161413;
+    --muted: #6f6a67;
+    --hair: #d6d1ce;
+    --panel: #ffffff;
+    --panel2: #e6e9ec;
+    --accent: #ec3013;
+    --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+    --mono: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #151312;
+      --ink: #f1eeec;
+      --muted: #a39c98;
+      --hair: #3a3533;
+      --panel: #1f1c1b;
+      --panel2: #262b30;
+      --accent: #ff5a3c;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #151312;
+    --ink: #f1eeec;
+    --muted: #a39c98;
+    --hair: #3a3533;
+    --panel: #1f1c1b;
+    --panel2: #262b30;
+    --accent: #ff5a3c;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 960px; margin: 0 auto; padding: 48px 24px 80px; }
+
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin: 0 0 12px;
+  }
+  h1 {
+    font-size: clamp(36px, 6vw, 56px);
+    font-weight: 800;
+    line-height: 1.02;
+    letter-spacing: -0.02em;
+    margin: 0 0 20px;
+    text-wrap: balance;
+  }
+  .dek {
+    font-size: 19px;
+    line-height: 1.45;
+    max-width: 62ch;
+    margin: 0 0 28px;
+  }
+  .meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0;
+    border-top: 2px solid var(--ink);
+    border-bottom: 2px solid var(--ink);
+    margin: 0 0 56px;
+  }
+  .meta div { padding: 14px 16px 14px 0; }
+  .meta div + div { border-left: 1px solid var(--hair); padding-left: 16px; }
+  .meta .k { font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
+  .meta .v { font-weight: 600; font-size: 17px; margin-top: 4px; font-variant-numeric: tabular-nums; }
+
+  section { border-top: 2px solid var(--ink); padding-top: 22px; margin-top: 56px; }
+  h2 {
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    line-height: 1.15;
+    margin: 0 0 12px;
+    text-wrap: balance;
+  }
+  p { max-width: 68ch; margin: 0 0 14px; }
+  p.lead { font-size: 17px; }
+
+  figure { margin: 28px 0 8px; }
+  figure svg { display: block; width: 100%; height: auto; color: var(--ink); }
+  figcaption {
+    font-size: 14px;
+    color: var(--muted);
+    max-width: 68ch;
+    margin: 12px 0 0;
+    line-height: 1.5;
+  }
+  figcaption b { color: var(--ink); font-weight: 600; }
+
+  /* SVG vocabulary */
+  .box { fill: var(--panel); stroke: currentColor; stroke-width: 1.4; }
+  .box.srv { fill: var(--panel2); }
+  .box.ghost { fill: none; stroke: var(--muted); stroke-dasharray: 4 4; }
+  .box.hotline { stroke: var(--accent); stroke-width: 2; }
+  .col { fill: none; stroke: var(--hair); stroke-width: 1.5; }
+  .col.srv { fill: var(--panel2); fill-opacity: 0.45; }
+  .t { font-family: var(--sans); font-size: 12.5px; font-weight: 600; fill: currentColor; }
+  .s { font-family: var(--mono); font-size: 10.5px; fill: var(--muted); }
+  .hd { font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; fill: var(--muted); }
+  .tag { font-family: var(--mono); font-size: 10.5px; fill: var(--accent); }
+  .lbl { font-family: var(--mono); font-size: 11px; fill: currentColor; }
+  .lbl.m { fill: var(--muted); }
+  .lbl.hot { fill: var(--accent); font-weight: 500; }
+  .bar { fill: var(--panel); stroke: currentColor; stroke-width: 1.2; }
+  .bar.hot { stroke: var(--accent); stroke-width: 1.8; }
+  .bt { font-family: var(--mono); font-size: 10px; fill: currentColor; }
+  .lane { stroke: var(--hair); stroke-width: 1.5; }
+  .ln { stroke: currentColor; stroke-width: 1.4; fill: none; }
+  .ln.d { stroke-dasharray: 4 3; }
+  .ln.hot { stroke: var(--accent); stroke-width: 2.4; }
+  .ln.hotd { stroke: var(--accent); stroke-width: 1.6; stroke-dasharray: 5 4; }
+  .halo { stroke: var(--bg); stroke-width: 7; fill: none; }
+  .arr polygon { fill: currentColor; }
+  .arrhot polygon { fill: var(--accent); }
+  .arrm polygon { fill: var(--muted); }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14.5px;
+    margin: 20px 0 0;
+  }
+  .tablewrap { overflow-x: auto; }
+  th, td { text-align: left; vertical-align: top; padding: 10px 14px 10px 0; border-bottom: 1px solid var(--hair); }
+  th { font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); font-weight: 500; border-bottom: 2px solid var(--ink); }
+  td code, p code, li code { font-family: var(--mono); font-size: 0.92em; }
+  td.mod { font-family: var(--mono); font-size: 13px; white-space: nowrap; }
+  .chip { display: inline-block; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase; padding: 2px 6px; border: 1px solid currentColor; margin-right: 6px; vertical-align: middle; }
+  .chip.r2 { color: var(--muted); }
+  .chip.hot { color: var(--accent); }
+
+  ul.changes { list-style: none; padding: 0; margin: 16px 0 0; max-width: 70ch; }
+  ul.changes li { padding: 12px 0; border-bottom: 1px solid var(--hair); display: grid; grid-template-columns: 150px 1fr; gap: 16px; }
+  ul.changes li:first-child { border-top: 1px solid var(--hair); }
+  ul.changes .from { font-family: var(--mono); font-size: 12px; color: var(--muted); text-decoration: line-through; padding-top: 3px; }
+  ul.changes .to { font-size: 15px; }
+  ul.changes .to b { font-weight: 600; }
+
+  a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 3px; }
+  a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  @media (max-width: 640px) {
+    ul.changes li { grid-template-columns: 1fr; gap: 4px; }
+  }
+</style>
+
+</head>
+<body>
+<main>
+  <p class="eyebrow">champi-android · redesign note · 2026-09-02</p>
+  <h1>Champi Thin Client</h1>
+  <p class="dek">The phone keeps its ears and its face. Everything that thinks, remembers, listens closely, or acts on your machines moves to a brain running where your GPUs are. One WebSocket replaces the whole on-device model stack.</p>
+  <div class="meta">
+    <div><div class="k">Round 1</div><div class="v">31 issues · thin client</div></div>
+    <div><div class="k">Round 2</div><div class="v">27 issues · deferred</div></div>
+    <div><div class="k">Stays on phone</div><div class="v">Wake word · VAD · Rive · tray</div></div>
+    <div><div class="k">Moves to brain</div><div class="v">STT · LLM · TTS · memory · tools</div></div>
+  </div>
+
+  <!-- ============ 1. BEFORE / AFTER ============ -->
+  <section>
+    <p class="eyebrow">01 · what changes</p>
+    <h2>Edge-first spec becomes a thin client</h2>
+    <p class="lead">The v0.3 spec put five inference stages and a routing policy inside the phone and left remote providers as stubs with transport out of scope. For a personal Jarvis the transport <em>is</em> the product, and the heavy stages already exist as champi-stt, champi-tts, and rc-mcp on your infrastructure.</p>
+
+    <figure>
+      <svg viewBox="0 0 960 400" role="img" aria-label="Left: spec v0.3 phone holds wake word, VAD, STT, LLM, TTS, routing policy and memory, with remote providers as an unavailable stub. Right: redesigned phone holds wake word, VAD, Rive bubble and tray, linked by one WebSocket to a brain holding gateway, STT, Claude, TTS, memory, rc-mcp tools and monitors.">
+        <defs>
+          <marker id="arr1" class="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+          <marker id="arr1m" class="arrm" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+          <marker id="arr1h" class="arrhot" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+        </defs>
+
+        <!-- LEFT: spec -->
+        <text class="hd" x="10" y="24">SPEC v0.3 · EDGE-FIRST</text>
+        <rect class="col" x="10" y="40" width="240" height="340"/>
+        <text class="s" x="26" y="60">Phone · everything on device</text>
+
+        <rect class="box" x="26" y="70" width="208" height="34"/>
+        <text class="t" x="36" y="92">Wake word</text>
+        <text class="s" x="226" y="92" text-anchor="end">stays</text>
+
+        <rect class="box" x="26" y="112" width="208" height="34"/>
+        <text class="t" x="36" y="134">VAD</text>
+        <text class="s" x="226" y="134" text-anchor="end">stays</text>
+
+        <rect class="box" x="26" y="154" width="208" height="34"/>
+        <text class="t" x="36" y="176">STT · whisper.cpp</text>
+        <text class="tag" x="226" y="176" text-anchor="end">→ brain</text>
+
+        <rect class="box" x="26" y="196" width="208" height="34"/>
+        <text class="t" x="36" y="218">LLM · on-device model</text>
+        <text class="tag" x="226" y="218" text-anchor="end">→ brain</text>
+
+        <rect class="box" x="26" y="238" width="208" height="34"/>
+        <text class="t" x="36" y="260">TTS · Piper</text>
+        <text class="tag" x="226" y="260" text-anchor="end">→ brain</text>
+
+        <rect class="box" x="26" y="280" width="208" height="34"/>
+        <text class="t" x="36" y="302">Routing policy · queue</text>
+        <text class="tag" x="226" y="302" text-anchor="end">removed</text>
+
+        <rect class="box" x="26" y="322" width="208" height="34"/>
+        <text class="t" x="36" y="344">Memory · context</text>
+        <text class="tag" x="226" y="344" text-anchor="end">→ brain</text>
+
+        <rect class="box ghost" x="290" y="150" width="190" height="110"/>
+        <text class="t" x="304" y="176">Remote providers</text>
+        <text class="s" x="304" y="196">stub · available() = false</text>
+        <text class="s" x="304" y="212">transport: out of scope</text>
+        <text class="s" x="304" y="228">never reached in v1</text>
+        <line class="ln d" x1="234" y1="213" x2="290" y2="205" marker-end="url(#arr1m)" stroke="var(--muted)"/>
+
+        <!-- RIGHT: redesign -->
+        <text class="hd" x="500" y="24">REDESIGN · THIN CLIENT</text>
+        <rect class="col" x="500" y="40" width="180" height="340"/>
+        <text class="s" x="516" y="60">Phone · ears and face</text>
+
+        <rect class="box" x="516" y="70" width="148" height="34"/>
+        <text class="t" x="526" y="92">Wake word</text>
+        <rect class="box" x="516" y="112" width="148" height="34"/>
+        <text class="t" x="526" y="134">VAD</text>
+        <rect class="box" x="516" y="154" width="148" height="34"/>
+        <text class="t" x="526" y="176">Rive bubble · panel</text>
+        <rect class="box" x="516" y="196" width="148" height="34"/>
+        <text class="t" x="526" y="218">Tray · share sheet</text>
+        <text class="s" x="516" y="352">no models</text>
+        <text class="s" x="516" y="366">no routing · no LLM</text>
+
+        <rect class="col srv" x="780" y="40" width="170" height="340"/>
+        <text class="s" x="796" y="60">Brain · your server</text>
+
+        <rect class="box hotline" x="796" y="70" width="138" height="34"/>
+        <text class="t" x="806" y="92">Gateway · WS</text>
+        <rect class="box" x="796" y="112" width="138" height="34"/>
+        <text class="t" x="806" y="134">STT · champi-stt</text>
+        <rect class="box" x="796" y="154" width="138" height="34"/>
+        <text class="t" x="806" y="176">LLM · Claude</text>
+        <rect class="box" x="796" y="196" width="138" height="34"/>
+        <text class="t" x="806" y="218">TTS · champi-tts</text>
+        <rect class="box" x="796" y="238" width="138" height="34"/>
+        <text class="t" x="806" y="260">Memory</text>
+        <rect class="box" x="796" y="280" width="138" height="34"/>
+        <text class="t" x="806" y="302">Tools · rc-mcp</text>
+        <rect class="box" x="796" y="322" width="138" height="34"/>
+        <text class="t" x="806" y="344">Monitors</text>
+
+        <line class="ln hot" x1="680" y1="87" x2="780" y2="87" marker-start="url(#arr1h)" marker-end="url(#arr1h)"/>
+        <text class="lbl hot" x="730" y="70" text-anchor="middle">WebSocket</text>
+        <text class="lbl" x="730" y="108" text-anchor="middle">→ PCM · text</text>
+        <text class="lbl" x="730" y="122" text-anchor="middle">← audio · text</text>
+        <text class="lbl m" x="730" y="140" text-anchor="middle">Tailscale</text>
+      </svg>
+      <figcaption><b>The one edge that changes everything.</b> Left, the spec's phone carries seven subsystems and a routing heuristic to decide between them. Right, four stay on the phone and a single authenticated WebSocket carries PCM and text up, audio and tokens down. The red-outlined gateway is the only new server component the phone knows about.</figcaption>
+    </figure>
+
+    <ul class="changes">
+      <li><span class="from">edge-first routing</span><span class="to"><b>Remote-first, one route.</b> No fits heuristic, no queue, no edge-only mode. Offline shows a banner and buffers text; that is round 2.</span></li>
+      <li><span class="from">120 MB memory budget</span><span class="to"><b>Phone stays under 60 MB</b> with only wake word and VAD models loaded. Battery target still matters because the mic loop is always on.</span></li>
+      <li><span class="from">providers:remote stub</span><span class="to"><b><code>:providers:remote</code> becomes the main provider.</b> One <code>BrainClient</code> satisfies <code>SttProvider</code>, <code>LlmProvider</code> and <code>TtsProvider</code> over the same socket.</span></li>
+      <li><span class="from">context windowing</span><span class="to"><b>The brain owns memory.</b> Ideas, commands and conversation live server-side. The phone keeps a local transcript cache so the panel reopens where you left it.</span></li>
+      <li><span class="from">privacy onboarding</span><span class="to"><b>One sentence in settings.</b> Audio leaves the phone only after wake or mic press, and only to your own server over Tailscale.</span></li>
+    </ul>
+  </section>
+
+  <!-- ============ 2. DATA FLOW ============ -->
+  <section>
+    <p class="eyebrow">02 · data flow</p>
+    <h2>Where each byte goes</h2>
+    <p class="lead">Three tiers. The phone produces PCM, text, and shared items and consumes tokens, audio, and pushes. The brain brokers streams and runs the agent loop. Your infrastructure does the heavy lifting and is reachable only over your private network.</p>
+
+    <figure>
+      <svg viewBox="0 0 960 470" role="img" aria-label="Three columns. Phone column with bubble, wake word and VAD, local cache, notification tray, share sheet. Brain column with gateway, agent loop, memory, scheduler. Infrastructure column with champi-stt, champi-tts, Claude API, rc-mcp, and GPUs, docker, services. Red arrows carry PCM, text and files from phone to gateway and audio, tokens and notifications back. Gateway exchanges PCM and transcripts with champi-stt, sentences and audio chunks with champi-tts. Agent loop exchanges prompts and tokens with Claude API and sends MCP tool calls to rc-mcp, whose agents reach GPUs, docker and services.">
+        <defs>
+          <marker id="arr2" class="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+          <marker id="arr2h" class="arrhot" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+        </defs>
+
+        <text class="hd" x="20" y="24">PHONE</text>
+        <text class="hd" x="360" y="24">BRAIN · YOUR SERVER</text>
+        <text class="hd" x="720" y="24">YOUR INFRASTRUCTURE</text>
+
+        <rect class="col" x="20" y="36" width="220" height="414"/>
+        <rect class="col srv" x="360" y="36" width="240" height="414"/>
+        <rect class="col srv" x="720" y="36" width="220" height="414"/>
+
+        <!-- Phone boxes -->
+        <rect class="box" x="36" y="60" width="188" height="44"/>
+        <text class="t" x="46" y="78">Bubble · panel</text>
+        <text class="s" x="46" y="94">Rive · Compose · state</text>
+        <text class="tag" x="214" y="78" text-anchor="end">◀ tokens</text>
+
+        <rect class="box" x="36" y="124" width="188" height="44"/>
+        <text class="t" x="46" y="142">Wake word · VAD</text>
+        <text class="s" x="46" y="158">on device · always on</text>
+        <text class="tag" x="214" y="142" text-anchor="end">PCM ▶</text>
+
+        <rect class="box" x="36" y="188" width="188" height="44"/>
+        <text class="t" x="46" y="206">Local cache</text>
+        <text class="s" x="46" y="222">Room transcript · DataStore</text>
+
+        <rect class="box" x="36" y="252" width="188" height="44"/>
+        <text class="t" x="46" y="270">Notification tray</text>
+        <text class="s" x="46" y="286">reply from lock screen</text>
+        <text class="tag" x="214" y="270" text-anchor="end">◀ push</text>
+
+        <rect class="box" x="36" y="316" width="188" height="44"/>
+        <text class="t" x="46" y="334">Share sheet</text>
+        <text class="s" x="46" y="350">idea inbox from any app</text>
+        <text class="tag" x="214" y="334" text-anchor="end">idea ▶</text>
+
+        <text class="s" x="36" y="438">brain client · one WebSocket</text>
+
+        <!-- Brain boxes -->
+        <rect class="box hotline" x="376" y="60" width="208" height="172"/>
+        <text class="t" x="386" y="80">Gateway</text>
+        <text class="s" x="386" y="96">auth · WS · stream broker</text>
+        <text class="s" x="386" y="128">· one session per phone</text>
+        <text class="s" x="386" y="144">· PCM ↔ champi-stt</text>
+        <text class="s" x="386" y="160">· sentences ↔ champi-tts</text>
+        <text class="s" x="386" y="176">· tokens and pushes ↓ phone</text>
+        <text class="s" x="386" y="192">· share items → agent loop</text>
+
+        <rect class="box" x="376" y="252" width="208" height="44"/>
+        <text class="t" x="386" y="270">Agent loop</text>
+        <text class="s" x="386" y="286">Claude · tools · confirmations</text>
+
+        <rect class="box" x="376" y="316" width="100" height="44"/>
+        <text class="t" x="386" y="334">Memory</text>
+        <text class="s" x="386" y="350">ideas · notes</text>
+
+        <rect class="box" x="484" y="316" width="100" height="44"/>
+        <text class="t" x="494" y="334">Scheduler</text>
+        <text class="s" x="494" y="350">cron checks</text>
+
+        <text class="s" x="376" y="438">python · champi-ipc · champi-signals</text>
+
+        <!-- Infra boxes -->
+        <rect class="box" x="736" y="124" width="188" height="44"/>
+        <text class="t" x="746" y="142">champi-stt</text>
+        <text class="s" x="746" y="158">Whisper on GPU · streaming</text>
+
+        <rect class="box" x="736" y="188" width="188" height="44"/>
+        <text class="t" x="746" y="206">champi-tts</text>
+        <text class="s" x="746" y="222">Kokoro on GPU · streaming</text>
+
+        <rect class="box" x="736" y="252" width="188" height="44"/>
+        <text class="t" x="746" y="270">Claude API</text>
+        <text class="s" x="746" y="286">Opus 5 · Sonnet 5 monitors</text>
+
+        <rect class="box" x="736" y="316" width="188" height="44"/>
+        <text class="t" x="746" y="334">rc-mcp</text>
+        <text class="s" x="746" y="350">server + agent per machine</text>
+
+        <rect class="box" x="736" y="380" width="188" height="44"/>
+        <text class="t" x="746" y="398">GPUs · docker · services</text>
+        <text class="s" x="746" y="414">shell · files · procs</text>
+
+        <text class="s" x="736" y="438">Tailscale · nothing public</text>
+
+        <!-- Phone <-> Gateway (hot) -->
+        <line class="ln hot" x1="240" y1="140" x2="376" y2="140" marker-end="url(#arr2h)"/>
+        <text class="lbl hot" x="308" y="133" text-anchor="middle">PCM · text · files</text>
+        <line class="ln hot" x1="376" y1="162" x2="240" y2="162" marker-end="url(#arr2h)"/>
+        <text class="lbl hot" x="308" y="178" text-anchor="middle">audio · tokens</text>
+        <text class="lbl hot" x="308" y="191" text-anchor="middle">notifications</text>
+
+        <!-- Gateway <-> STT -->
+        <line class="ln" x1="584" y1="140" x2="736" y2="140" marker-end="url(#arr2)"/>
+        <text class="lbl" x="660" y="133" text-anchor="middle">PCM stream</text>
+        <line class="ln" x1="736" y1="162" x2="584" y2="162" marker-end="url(#arr2)"/>
+        <text class="lbl" x="660" y="178" text-anchor="middle">transcripts</text>
+
+        <!-- Gateway <-> TTS -->
+        <line class="ln" x1="584" y1="204" x2="736" y2="204" marker-end="url(#arr2)"/>
+        <text class="lbl" x="660" y="197" text-anchor="middle">sentences</text>
+        <line class="ln" x1="736" y1="226" x2="584" y2="226" marker-end="url(#arr2)"/>
+        <text class="lbl" x="660" y="240" text-anchor="middle">audio chunks</text>
+
+        <!-- Gateway <-> Agent loop -->
+        <line class="ln" x1="470" y1="232" x2="470" y2="252" marker-end="url(#arr2)"/>
+        <line class="ln" x1="490" y1="252" x2="490" y2="232" marker-end="url(#arr2)"/>
+        <text class="lbl" x="500" y="246">text ↓ tokens ↑</text>
+
+        <!-- Agent loop <-> Claude API -->
+        <line class="ln" x1="584" y1="272" x2="736" y2="272" marker-start="url(#arr2)" marker-end="url(#arr2)"/>
+        <text class="lbl" x="660" y="265" text-anchor="middle">messages ↔ tokens</text>
+
+        <!-- Agent loop -> rc-mcp (orthogonal) -->
+        <polyline class="ln" points="584,292 650,292 650,338 736,338" marker-end="url(#arr2)"/>
+        <text class="lbl" x="656" y="326">MCP tools</text>
+
+        <!-- rc-mcp -> machines -->
+        <line class="ln" x1="830" y1="360" x2="830" y2="380" marker-end="url(#arr2)"/>
+        <text class="lbl m" x="838" y="374">agents</text>
+
+        <!-- Memory / Scheduler <-> Agent loop -->
+        <line class="ln" x1="426" y1="316" x2="426" y2="296" marker-start="url(#arr2)" marker-end="url(#arr2)"/>
+        <line class="ln" x1="534" y1="316" x2="534" y2="296" marker-end="url(#arr2)"/>
+        <text class="lbl m" x="542" y="310">wakes</text>
+      </svg>
+      <figcaption><b>Red is the only path that leaves the phone.</b> Everything the phone sends goes to the gateway; everything it shows comes back on the same socket. The gateway streams PCM to champi-stt and sentences to champi-tts so the agent loop only ever sees text. The scheduler wakes the loop on a cron for GPU, service, and repo checks, and anything worth saying comes back to the phone as a notification. Ideas from the share sheet land in memory through the same loop.</figcaption>
+    </figure>
+  </section>
+
+  <!-- ============ 3. VOICE TURN ============ -->
+  <section>
+    <p class="eyebrow">03 · one voice turn</p>
+    <h2>Wake to speech, and what barge-in cancels</h2>
+    <p class="lead">Only the first 150 ms happen on the phone. From wake onward the phone streams PCM and plays what comes back. Barge-in is a single cancel that runs down every lane at once.</p>
+
+    <figure>
+      <svg viewBox="0 0 960 344" role="img" aria-label="Timeline with five lanes: phone, gateway, STT, Claude, TTS. Wake word on the phone starts PCM streaming to gateway and STT. STT returns partials then a final transcript to Claude. Claude streams tokens to TTS and to the phone. TTS returns audio which the phone plays. When the user speaks over playback, barge-in cancels TTS, tokens and playback and the phone is listening again. Target from end of speech to first audio is 1.5 seconds.">
+        <defs>
+          <marker id="arr3" class="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><polygon points="0,0 10,5 0,10"/></marker>
+        </defs>
+
+        <text class="lbl m" x="940" y="32" text-anchor="end">not to scale</text>
+
+        <!-- lanes -->
+        <text class="t" x="112" y="60" text-anchor="end">Phone</text>
+        <text class="t" x="112" y="110" text-anchor="end">Gateway</text>
+        <text class="t" x="112" y="160" text-anchor="end">STT · GPU</text>
+        <text class="t" x="112" y="210" text-anchor="end">Claude</text>
+        <text class="t" x="112" y="260" text-anchor="end">TTS · GPU</text>
+        <line class="lane" x1="124" y1="56" x2="940" y2="56"/>
+        <line class="lane" x1="124" y1="106" x2="940" y2="106"/>
+        <line class="lane" x1="124" y1="156" x2="940" y2="156"/>
+        <line class="lane" x1="124" y1="206" x2="940" y2="206"/>
+        <line class="lane" x1="124" y1="256" x2="940" y2="256"/>
+
+        <!-- Phone bars -->
+        <rect class="bar" x="124" y="45" width="106" height="22"/>
+        <text class="bt" x="130" y="60">idle · wake word</text>
+        <rect class="bar" x="230" y="45" width="190" height="22"/>
+        <text class="bt" x="236" y="60">LISTENING · streams PCM</text>
+        <rect class="bar" x="560" y="45" width="100" height="22"/>
+        <text class="bt" x="566" y="60">SPEAKING · play</text>
+        <rect class="bar hot" x="660" y="45" width="120" height="22"/>
+        <text class="bt" x="666" y="60">LISTENING again</text>
+
+        <!-- wake tick + label -->
+        <line class="ln hot" x1="230" y1="38" x2="230" y2="74"/>
+        <text class="lbl hot" x="234" y="34">wake · ≤150 ms to LISTENING</text>
+        <!-- end of speech tick -->
+        <line class="ln" x1="420" y1="40" x2="420" y2="72" stroke="var(--muted)"/>
+        <text class="lbl m" x="424" y="34">VAD: end of speech</text>
+
+        <!-- Gateway bars -->
+        <rect class="bar" x="236" y="95" width="190" height="22"/>
+        <text class="bt" x="242" y="110">PCM → STT · partials ↑</text>
+        <rect class="bar" x="520" y="95" width="140" height="22"/>
+        <text class="bt" x="526" y="110">tokens + audio → phone</text>
+
+        <!-- STT bar -->
+        <rect class="bar" x="246" y="145" width="190" height="22"/>
+        <text class="bt" x="252" y="160">Whisper streaming · partials</text>
+
+        <!-- Claude bar -->
+        <rect class="bar" x="446" y="195" width="214" height="22"/>
+        <text class="bt" x="452" y="210">Opus 5 · streams tokens</text>
+
+        <!-- TTS bar -->
+        <rect class="bar" x="476" y="245" width="184" height="22"/>
+        <text class="bt" x="482" y="260">Kokoro · sentence → audio</text>
+
+        <!-- arrows -->
+        <line class="ln" x1="300" y1="67" x2="300" y2="95" marker-end="url(#arr3)"/>
+        <text class="lbl" x="305" y="85">PCM</text>
+        <line class="ln" x1="310" y1="117" x2="310" y2="145" marker-end="url(#arr3)"/>
+
+        <line class="ln d" x1="380" y1="145" x2="380" y2="117" marker-end="url(#arr3)"/>
+        <line class="ln d" x1="380" y1="95" x2="380" y2="67" marker-end="url(#arr3)"/>
+        <text class="lbl" x="385" y="85">partials</text>
+
+        <line class="ln" x1="440" y1="160" x2="440" y2="195" marker-end="url(#arr3)"/>
+        <text class="lbl" x="445" y="186">final text</text>
+
+        <line class="ln" x1="480" y1="217" x2="480" y2="245" marker-end="url(#arr3)"/>
+        <text class="lbl" x="485" y="236">sentences</text>
+
+        <line class="ln d" x1="530" y1="195" x2="530" y2="117" marker-end="url(#arr3)"/>
+        <text class="lbl" x="525" y="140" text-anchor="end">tokens</text>
+        <line class="ln d" x1="530" y1="95" x2="530" y2="67" marker-end="url(#arr3)"/>
+
+        <line class="halo" x1="560" y1="245" x2="560" y2="117"/>
+        <line class="ln" x1="560" y1="245" x2="560" y2="117" marker-end="url(#arr3)"/>
+        <text class="lbl" x="565" y="236">first audio</text>
+        <line class="ln" x1="560" y1="95" x2="560" y2="67" marker-end="url(#arr3)"/>
+
+        <!-- barge-in -->
+        <line class="ln hotd" x1="660" y1="40" x2="660" y2="276"/>
+        <text class="lbl hot" x="660" y="296" text-anchor="middle">barge-in · user speaks over playback → cancel TTS, tokens, playback → LISTENING</text>
+
+        <!-- latency bracket -->
+        <line class="ln" x1="420" y1="314" x2="560" y2="314" stroke="var(--muted)"/>
+        <line class="ln" x1="420" y1="309" x2="420" y2="319" stroke="var(--muted)"/>
+        <line class="ln" x1="560" y1="309" x2="560" y2="319" stroke="var(--muted)"/>
+        <text class="lbl m" x="490" y="334" text-anchor="middle">end of speech → first audio · target ≤ 1.5 s over LAN with GPU STT and TTS</text>
+      </svg>
+      <figcaption><b>The Claude lane stands for the agent loop calling the Claude API.</b> Partials flow back to the panel while you are still talking, so the transcript is visible before Whisper finalises. TTS starts on the first complete sentence, not the full answer, which is what keeps the 1.5 s target reachable. The dashed red line is one structured-concurrency cancel: playback, synthesis, and generation are children of the same voice scope.</figcaption>
+    </figure>
+  </section>
+
+  <!-- ============ 4. MODULES ============ -->
+  <section>
+    <p class="eyebrow">04 · module map</p>
+    <h2>What each Gradle module does in round 1</h2>
+    <p class="lead">The eleven-module layout from the spec survives. Three modules shrink, one flips from stub to centrepiece, and two wait for round 2.</p>
+
+    <div class="tablewrap">
+    <table>
+      <thead><tr><th>Module</th><th>Round 1 role</th><th>Change from spec</th></tr></thead>
+      <tbody>
+        <tr><td class="mod">:app</td><td>Foreground service, permissions, minimal settings: server address, wake word toggle</td><td>Full settings and onboarding deferred <span class="chip r2">round 2</span></td></tr>
+        <tr><td class="mod">:overlay</td><td>Bubble, drag and snap, panel, voice controls, notification open</td><td>Remote badge and routing footer removed. Header shows connected or offline.</td></tr>
+        <tr><td class="mod">:character</td><td>Rive artboard, seven states, level and attention inputs</td><td>Unchanged</td></tr>
+        <tr><td class="mod">:audio</td><td>AudioCapture, PlaybackQueue, wake word and VAD hosting, amplitude for <code>level</code></td><td>Unchanged. Echo cancellation still matters for barge-in.</td></tr>
+        <tr><td class="mod">:providers:api</td><td>Same interfaces</td><td>Unchanged. <code>SttProvider</code>, <code>LlmProvider</code>, <code>TtsProvider</code> are now implemented by one class.</td></tr>
+        <tr><td class="mod">:providers:edge</td><td>Wake word and Silero VAD only</td><td>Edge LLM, whisper.cpp, Piper deferred <span class="chip r2">round 2</span></td></tr>
+        <tr><td class="mod">:providers:remote</td><td><code>BrainClient</code>: WebSocket, auth, PCM up, audio and token streams down, reconnect</td><td><span class="chip hot">flipped</span> Was contract only with transport out of scope. Now the main provider.</td></tr>
+        <tr><td class="mod">:assistant</td><td>Turn orchestration, voice turn, barge-in, AppState, per-turn latency</td><td>Routing policy, fits heuristic, queue, context windowing removed. Brain owns memory.</td></tr>
+        <tr><td class="mod">:actions</td><td>Empty</td><td>Alarms, timers, calendar deferred <span class="chip r2">round 2</span></td></tr>
+        <tr><td class="mod">:context</td><td>Share sheet receiver into the conversation</td><td>Periodic context signals deferred <span class="chip r2">round 2</span></td></tr>
+        <tr><td class="mod">:core</td><td>AppState, DataStore, Room for transcript cache</td><td>Model storage and versioning utilities deferred <span class="chip r2">round 2</span></td></tr>
+      </tbody>
+    </table>
+    </div>
+  </section>
+
+  <!-- ============ 5. BRAIN ============ -->
+  <section>
+    <p class="eyebrow">05 · the other half</p>
+    <h2>Brain components that do not exist yet</h2>
+    <p class="lead">champi-stt, champi-tts, and rc-mcp are mature. The current champi orchestrator is a single-turn call with no tools, no history, and no memory. These five pieces turn it into the brain the phone talks to.</p>
+
+    <div class="tablewrap">
+    <table>
+      <thead><tr><th>Component</th><th>Job</th><th>Builds on</th><th>Agent-days</th></tr></thead>
+      <tbody>
+        <tr><td class="mod">gateway</td><td>Authenticated WebSocket per phone, stream broker between phone, STT and TTS, push channel</td><td>champi-stt web server, champi-ipc</td><td>2 to 3</td></tr>
+        <tr><td class="mod">agent loop</td><td>Claude with tool use, confirmations for destructive calls, streaming tokens</td><td>Claude API tool runner, rc-mcp as MCP toolset</td><td>3 to 5</td></tr>
+        <tr><td class="mod">memory</td><td>Ideas, commands, journal. Every utterance tagged and searchable. Context assembly per turn</td><td>SQLite plus embeddings, or the Claude memory tool</td><td>2 to 4</td></tr>
+        <tr><td class="mod">scheduler</td><td>Cron-fired checks on GPUs, services, repos. Findings become notifications to the phone</td><td>Sonnet 5 for cheap monitors, Opus 5 for the main loop</td><td>2 to 3</td></tr>
+        <tr><td class="mod">stt / tts services</td><td>Streaming endpoints around Whisper and Kokoro on the GPU box</td><td>champi-stt, champi-tts as they are</td><td>2 to 3</td></tr>
+      </tbody>
+    </table>
+    </div>
+    <p style="margin-top:20px">Build the brain first. It is usable from the desktop through champi-stt on day one, and every round 1 phone issue then has a real server to talk to instead of a stub. The issue split lives in <a href="https://github.com/champi-ai/champi-mobile/blob/main/docs/rounds.md">docs/rounds.md</a> on the working branch.</p>
+  </section>
+</main>
+
+</body>
+</html>

--- a/docs/design/thin-client.md
+++ b/docs/design/thin-client.md
@@ -1,0 +1,115 @@
+# Champi Thin Client
+
+**Status:** proposed redesign · **Date:** 2026-09-02 · **Supersedes:** the edge-first routing in [`docs/specs/mobile.md`](../specs/mobile.md) §2.4, §3.3 for round 1
+
+The phone keeps its ears and its face. Everything that thinks, remembers, listens closely, or acts on your machines moves to a brain running where your GPUs are. One WebSocket replaces the whole on-device model stack.
+
+A styled version of this document with the same figures is at [`thin-client.html`](./thin-client.html).
+
+| | |
+|---|---|
+| Round 1 | 31 issues · thin client |
+| Round 2 | 27 issues · deferred |
+| Stays on phone | Wake word · VAD · Rive · tray |
+| Moves to brain | STT · LLM · TTS · memory · tools |
+
+The issue split is in [`docs/rounds.md`](../rounds.md).
+
+---
+
+## 01 · What changes
+
+The v0.3 spec put five inference stages and a routing policy inside the phone and left remote providers as stubs with transport out of scope. For a personal Jarvis the transport *is* the product, and the heavy stages already exist as champi-stt, champi-tts, and rc-mcp on your infrastructure.
+
+![Before: spec v0.3 phone with wake word, VAD, STT, LLM, TTS, routing and memory, plus an unavailable remote stub. After: phone with wake word, VAD, Rive bubble and tray linked by one WebSocket to a brain with gateway, STT, Claude, TTS, memory, rc-mcp tools and monitors.](./figures/01-before-after.svg)
+
+**The one edge that changes everything.** Left, the spec's phone carries seven subsystems and a routing heuristic to decide between them. Right, four stay on the phone and a single authenticated WebSocket carries PCM and text up, audio and tokens down. The red-outlined gateway is the only new server component the phone knows about.
+
+| Spec v0.3 | Thin client |
+|---|---|
+| Edge-first routing with a fits heuristic, queue, and edge-only mode | **Remote-first, one route.** Offline shows a banner and buffers text; that is round 2. |
+| 120 MB resident memory budget for five models | **Phone stays under 60 MB** with only wake word and VAD loaded. Battery still matters because the mic loop is always on. |
+| `:providers:remote` is a stub, transport out of scope | **`:providers:remote` becomes the main provider.** One `BrainClient` satisfies `SttProvider`, `LlmProvider` and `TtsProvider` over the same socket. |
+| Context windowing on the phone | **The brain owns memory.** Ideas, commands and conversation live server-side. The phone keeps a local transcript cache so the panel reopens where you left it. |
+| Multi-step privacy onboarding | **One sentence in settings.** Audio leaves the phone only after wake or mic press, and only to your own server over Tailscale. |
+
+---
+
+## 02 · Data flow
+
+Three tiers. The phone produces PCM, text, and shared items and consumes tokens, audio, and pushes. The brain brokers streams and runs the agent loop. Your infrastructure does the heavy lifting and is reachable only over your private network.
+
+![Three columns: phone, brain, infrastructure. Red arrows carry PCM, text and files from phone to gateway and audio, tokens and notifications back. Gateway exchanges PCM and transcripts with champi-stt, sentences and audio chunks with champi-tts. Agent loop exchanges messages and tokens with the Claude API and sends MCP tool calls to rc-mcp, whose agents reach GPUs, docker and services.](./figures/02-data-flow.svg)
+
+**Red is the only path that leaves the phone.** Everything the phone sends goes to the gateway; everything it shows comes back on the same socket. The gateway streams PCM to champi-stt and sentences to champi-tts so the agent loop only ever sees text. The scheduler wakes the loop on a cron for GPU, service, and repo checks, and anything worth saying comes back to the phone as a notification. Ideas from the share sheet land in memory through the same loop.
+
+| Hop | Carries | Direction |
+|---|---|---|
+| Phone → Gateway | PCM frames after wake or mic press, typed text, shared files | up |
+| Gateway → Phone | Transcript partials, tokens, TTS audio chunks, notifications | down |
+| Gateway ↔ champi-stt | PCM stream in, partial and final transcripts out | both |
+| Gateway ↔ champi-tts | Sentence chunks in, audio chunks out | both |
+| Gateway ↔ Agent loop | Final text and share items in, tokens and pushes out | both |
+| Agent loop ↔ Claude API | Messages and tool specs in, tokens and tool calls out | both |
+| Agent loop → rc-mcp | MCP tool calls; destructive calls require confirmation | down |
+| rc-mcp → machines | Agents dial out from each machine: shell, files, processes, sysinfo | down |
+| Scheduler → Agent loop | Cron wake-ups for monitoring checks | in |
+| Agent loop ↔ Memory | Recall before a turn, write after; ideas and notes | both |
+
+---
+
+## 03 · One voice turn
+
+Only the first 150 ms happen on the phone. From wake onward the phone streams PCM and plays what comes back. Barge-in is a single cancel that runs down every lane at once.
+
+![Timeline with lanes for phone, gateway, STT, Claude and TTS. Wake word starts PCM streaming; STT returns partials then a final transcript to Claude; Claude streams tokens to TTS and the phone; TTS returns audio the phone plays. When the user speaks over playback, barge-in cancels TTS, tokens and playback and the phone is listening again.](./figures/03-voice-turn.svg)
+
+**The Claude lane stands for the agent loop calling the Claude API.** Partials flow back to the panel while you are still talking, so the transcript is visible before Whisper finalises. TTS starts on the first complete sentence, not the full answer, which is what keeps the 1.5 s target reachable. The dashed red line is one structured-concurrency cancel: playback, synthesis, and generation are children of the same voice scope.
+
+Targets carried over from the spec:
+
+| Measure | Target |
+|---|---|
+| Wake → `LISTENING` indicator | ≤ 150 ms, on device |
+| End of speech → first TTS audio | ≤ 1.5 s p50 over LAN with GPU STT and TTS |
+| Barge-in → playback stopped | ≤ 500 ms |
+
+---
+
+## 04 · Module map
+
+The eleven-module layout from the spec survives. Three modules shrink, one flips from stub to centrepiece, and two wait for round 2.
+
+| Module | Round 1 role | Change from spec |
+|---|---|---|
+| `:app` | Foreground service, permissions, minimal settings: server address, wake word toggle | Full settings and onboarding deferred (round 2) |
+| `:overlay` | Bubble, drag and snap, panel, voice controls, notification open | Remote badge and routing footer removed. Header shows connected or offline. |
+| `:character` | Rive artboard, seven states, `level` and `attention` inputs | Unchanged |
+| `:audio` | AudioCapture, PlaybackQueue, wake word and VAD hosting, amplitude for `level` | Unchanged. Echo cancellation still matters for barge-in. |
+| `:providers:api` | Same interfaces | Unchanged. `SttProvider`, `LlmProvider`, `TtsProvider` are now implemented by one class. |
+| `:providers:edge` | Wake word and Silero VAD only | Edge LLM, whisper.cpp, Piper deferred (round 2) |
+| `:providers:remote` | `BrainClient`: WebSocket, auth, PCM up, audio and token streams down, reconnect | **Flipped.** Was contract only with transport out of scope. Now the main provider. |
+| `:assistant` | Turn orchestration, voice turn, barge-in, `AppState`, per-turn latency | Routing policy, fits heuristic, queue, context windowing removed. Brain owns memory. |
+| `:actions` | Empty | Alarms, timers, calendar deferred (round 2) |
+| `:context` | Share sheet receiver into the conversation | Periodic context signals deferred (round 2) |
+| `:core` | `AppState`, DataStore, Room for transcript cache | Model storage and versioning utilities deferred (round 2) |
+
+---
+
+## 05 · Brain components that do not exist yet
+
+champi-stt, champi-tts, and rc-mcp are mature. The current champi orchestrator is a single-turn call with no tools, no history, and no memory. These five pieces turn it into the brain the phone talks to.
+
+| Component | Job | Builds on | Agent-days |
+|---|---|---|---|
+| gateway | Authenticated WebSocket per phone, stream broker between phone, STT and TTS, push channel | champi-stt web server, champi-ipc | 2 to 3 |
+| agent loop | Claude with tool use, confirmations for destructive calls, streaming tokens | Claude API tool runner, rc-mcp as MCP toolset | 3 to 5 |
+| memory | Ideas, commands, journal. Every utterance tagged and searchable. Context assembly per turn | SQLite plus embeddings, or the Claude memory tool | 2 to 4 |
+| scheduler | Cron-fired checks on GPUs, services, repos. Findings become notifications to the phone | Sonnet 5 for cheap monitors, Opus 5 for the main loop | 2 to 3 |
+| stt / tts services | Streaming endpoints around Whisper and Kokoro on the GPU box | champi-stt, champi-tts as they are | 2 to 3 |
+
+Build the brain first. It is usable from the desktop through champi-stt on day one, and every round 1 phone issue then has a real server to talk to instead of a stub.
+
+## Open decision
+
+The phone keeps no LLM at all in round 1, so with no network it shows an offline banner rather than answering. A small on-device fallback moves #18 back into round 1 and adds about a week.

--- a/docs/rounds.md
+++ b/docs/rounds.md
@@ -1,0 +1,81 @@
+# Build rounds
+
+Issue priority for a personal, thin-client build of champi-android. The phone does wake word and VAD on device and streams everything else to the champi brain on your own infrastructure. Labels `round:1` and `round:2` on GitHub mirror this file.
+
+**Round 1** builds the always-on client: overlay skeleton, character and interaction, text loop against the brain, on-device wake word and VAD with server STT and TTS, barge-in, proactive notifications, and the share sheet as an idea inbox. 31 issues.
+
+**Round 2** is everything that serves strangers, offline use, or polish: on-device models, edge-first routing, profiling, localization, crash reporting, release channel, accessibility, and device actions. 27 issues.
+
+## Round 1
+
+| Issue | Phase | Title |
+|---|---|---|
+| #3 | M0 | [INFRA]: Gradle multi-module scaffold |
+| #4 | M0 | [INFRA]: Hilt/Dagger DI graph wired across modules |
+| #5 | M0 | [INFRA]: Manifest permissions, foreground service declarations, and boot receiver |
+| #6 | M0 | [INFRA]: CI pipeline — assembleDebug and lint on pull requests |
+| #7 | M0 | [OVERLAY]: WindowManager overlay host and ComposeView lifecycle wiring |
+| #8 | M0 | [APP]: ChampiService foreground service, persistent notification, and runtime permission requests |
+| #9 | M1 | [INFRA]: AppState StateFlow definition and DataStore setup |
+| #10 | M1 | [OVERLAY]: Drag gesture, snap-to-edge, and position persistence |
+| #11 | M1 | [OVERLAY]: Dismiss zone and peek state |
+| #12 | M1 | [OVERLAY]: Conversation panel shell — bottom sheet expand, collapse, and IME avoidance |
+| #13 | M1 | [OVERLAY]: Long-press quick-actions surface |
+| #14 | M1 | [CHARACTER]: Rive artboard integration and AppState-to-state-machine input bridge |
+| #15 | M1 | [CHARACTER]: Dual-scale rendering from one artboard and interruptible state transitions |
+| #16 | M2 | [INFRA]: Room database schema — conversations and messages, plus model storage utilities |
+| #17 | M2 | [PROVIDERS]: Provider API interface definitions |
+| #19 | M2 | [ASSISTANT]: ConversationManager — turn management and Room persistence |
+| #20 | M2 | [ASSISTANT]: TurnOrchestrator — text input to streamed LLM response pipeline |
+| #21 | M2 | [OVERLAY]: Conversation panel message list and input row |
+| #22 | M2 | [OVERLAY]: Character state wiring for text turn lifecycle in the panel |
+| #23 | M3 | [INFRA]: :audio module — AudioCapture, PlaybackQueue, and RECORD_AUDIO permission |
+| #24 | M3 | [PROVIDERS]: WakeWordProvider edge implementation |
+| #25 | M3 | [PROVIDERS]: VadProvider edge implementation — Silero VAD |
+| #28 | M3 | [ASSISTANT]: VoiceTurnOrchestrator — wake-to-TTS pipeline and per-turn routing metadata |
+| #29 | M3 | [ASSISTANT]: Barge-in — interrupt TTS playback on user speech onset |
+| #30 | M3 | [CHARACTER]: Level input driven by mic amplitude and TTS playback amplitude |
+| #31 | M3 | [OVERLAY]: Voice panel controls — mic button, TTS stop, routing footer, and provider header tag |
+| #38 | M5 | [INFRA]: System tray notification with reply actions, Quick Settings tile, and DataStore for action/rate-limit settings |
+| #39 | M5 | [ASSISTANT]: Proactive notification engine and client-side rate limiter |
+| #43 | M5 | [CHARACTER]: notifying state activation — bubble pulse on proactive notification |
+| #44 | M5 | [OVERLAY]: Notification action open, inline action cards, and destructive action confirmation dialog |
+| #46 | M6 | [PROVIDERS]: Share-sheet receiver — text, links, images, and files into the conversation |
+
+Note on #19 to #22: the `LlmProvider` behind the text loop is a brain client over WebSocket, not the edge LLM from #18. Note on #28 and #29: STT and TTS stages stream to and from the server; only wake word (#24) and VAD (#25) run on the phone.
+
+## Round 2
+
+| Issue | Phase | Title | Why it waits |
+|---|---|---|---|
+| #18 | M2 | [PROVIDERS]: Edge LLM provider — on-device model integration and download-on-first-use | On-device LLM. The brain runs the model on your GPUs or Claude. |
+| #26 | M3 | [PROVIDERS]: SttProvider edge implementation — whisper.cpp or Android on-device SpeechRecognizer | On-device STT. champi-stt streams Whisper from the server. |
+| #27 | M3 | [PROVIDERS]: TtsProvider edge implementation — Android TextToSpeech or Piper | On-device neural TTS. champi-tts serves Kokoro from the server. |
+| #32 | M4 | [INFRA]: DataStore settings for routing and queued turns Room schema | Routing settings and queued-turn schema only matter with two LLM tiers. |
+| #33 | M4 | [PROVIDERS]: Remote provider stubs and provider capabilities reporting | Remote stubs are replaced by the real brain client in round 1. |
+| #34 | M4 | [ASSISTANT]: RoutingPolicy — edge-first provider selection, fits heuristic, and decision logging | Edge-first routing heuristic. Thin client has one route. |
+| #35 | M4 | [ASSISTANT]: Turn queuing and degraded mode | Turn queuing and degraded mode. Replace with a simple offline banner later. |
+| #36 | M4 | [OVERLAY]: Remote badge in panel header and routing explanation in turn footer | Remote badge and routing explanation. Everything is remote by design. |
+| #37 | M4 | [APP]: Settings screen — provider pipeline, downloaded model management, and edge-only toggle | Provider pipeline settings. No provider choice in the thin client. |
+| #40 | M5 | [ASSISTANT]: Tool-call flow — LLM toolCall events routed through ActionProvider to ToolResult | Tool calls execute in the brain. Phone-side action dispatch comes later. |
+| #41 | M5 | [ACTIONS]: ActionProvider for alarms and timers | Alarm and timer actions. Useful, but depends on #40. |
+| #42 | M5 | [ACTIONS]: ActionProvider for calendar events | Calendar actions. Depends on #40. |
+| #45 | M6 | [INFRA]: Performance profiling — battery, latency, memory, Rive CPU, and cold start | Formal profiling pass against public-release targets. |
+| #47 | M6 | [PROVIDERS]: Optional periodic context provider — location, battery, connectivity, and foreground app | Periodic context signals. Add once the brain has a use for them. |
+| #48 | M6 | [ASSISTANT]: Multi-modal turn support — images and files as conversation context | Multi-modal turns. Add after text and voice are solid. |
+| #49 | M6 | [OVERLAY]: Attach button — image picker, file picker, camera capture, and share-sheet payload display | Attach button and camera. Share sheet (#46) covers idea capture first. |
+| #50 | M6 | [APP]: Launcher icon opens panel, CAMERA permission, and ACCESS_COARSE_LOCATION permission wiring | Launcher entry and camera and location permissions. Follows #47 and #49. |
+| #51 | M7 | [INFRA]: es-MX and en-US string localization across all modules | Two-locale localization. Ship in your language only. |
+| #52 | M7 | [INFRA]: Crash reporting and crash-free session tracking | Crash reporter. Logcat is enough for a handful of users. |
+| #53 | M7 | [INFRA]: Self-hosted APK release channel — signed builds, update check, and OEM battery guidance | Self-hosted release channel and OEM guidance. Sideload the APK. |
+| #54 | M7 | [INFRA]: Edge model lifecycle — deletable from settings, versioned, lazy-loaded, memory-pressure unloading, and privacy compliance | Edge model lifecycle. No edge models in round 1. |
+| #55 | M7 | [APP]: Onboarding flow with required privacy disclosure | Full onboarding flow. The basic permission screen from #8 is enough. |
+| #56 | M7 | [APP]: Full settings screen — voice, providers, actions, bubble, and proactive-interrupt settings | Full settings screen. Round 1 needs only server address and wake word toggle. |
+| #57 | M7 | [OVERLAY]: DND schedule — bubble auto-hide and wake word suspension during quiet hours | DND schedule and full-screen detection. Comfort feature. |
+| #58 | M7 | [OVERLAY]: TalkBack accessibility — labels on bubble, panel, quick actions, and all interactive elements | TalkBack pass. Only if someone in the group needs it. |
+| #59 | M7 | [CHARACTER]: sleeping state visual treatment and earcons | Sleeping state and earcons. Polish. |
+| #60 | M7 | [ASSISTANT]: Conversation memory management — context windowing for edge and remote LLM | Context windowing. The brain owns conversation memory. |
+
+## Applying the labels
+
+Run `scripts/label-rounds.sh` with a `gh` login that can write issues. It creates the two labels if missing and adds one to each issue without touching existing labels.

--- a/scripts/label-rounds.sh
+++ b/scripts/label-rounds.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Apply round:1 / round:2 labels to champi-mobile issues. Requires gh CLI with issues:write.
+set -euo pipefail
+REPO="${REPO:-champi-ai/champi-mobile}"
+
+gh label create 'round:1' --repo "$REPO" --color 0e8a16 --description 'Thin-client MVP: build first' --force
+gh label create 'round:2' --repo "$REPO" --color c5def5 --description 'Deferred: polish, offline, public-release scope' --force
+
+ROUND1=(3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 19 20 21 22 23 24 25 28 29 30 31 38 39 43 44 46)
+ROUND2=(18 26 27 32 33 34 35 36 37 40 41 42 45 47 48 49 50 51 52 53 54 55 56 57 58 59 60)
+
+for n in "${ROUND1[@]}"; do gh issue edit "$n" --repo "$REPO" --add-label 'round:1'; done
+for n in "${ROUND2[@]}"; do gh issue edit "$n" --repo "$REPO" --add-label 'round:2'; done
+echo "Labelled ${#ROUND1[@]} round:1 and ${#ROUND2[@]} round:2 issues."


### PR DESCRIPTION
## Summary

Re-scopes champi-android for a personal Jarvis build: the phone becomes a thin client that keeps wake word, VAD, the Rive character and notifications on device and streams everything else to a brain running on the owner's own infrastructure. Documents the architecture and records which of the 58 issues are built first.

## Changes

- `docs/design/thin-client.md`: the redesign note. What moves off the phone, the full data flow across phone, brain and infrastructure, one voice turn with barge-in, the per-module changes, and the five brain components still to build. GitHub renders the figures inline.
- `docs/design/figures/*.svg`: three standalone figures (before/after, data flow, voice turn).
- `docs/design/thin-client.html`: the same document as a self-contained styled page using the spec's design system (Archivo, red accent on off-white, zero radius).
- `docs/rounds.md`: the round 1 (31 issues) / round 2 (27 issues) split with a one-line reason per deferred issue. Labels `round:1` and `round:2` have been applied on GitHub to match.
- `scripts/label-rounds.sh`: reapplies the labels with `gh` if they ever need restoring.

## Notes

- Docs only, no code.
- Supersedes the edge-first routing in `docs/specs/mobile.md` §2.4 and §3.3 for round 1; the spec itself is unchanged in this PR.
- Open decision recorded in the doc: the round 1 phone has no on-device LLM, so offline shows a banner rather than answering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7PobEkzn84vAJSg1HiJ4y

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7PobEkzn84vAJSg1HiJ4y)_