### PR TITLE
feat(di): wire Hilt/Dagger DI graph across all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Convention plugins (`build-logic`) for shared Android configuration: `minSdk 29`, `targetSdk 35`, `compileSdk 35`, Kotlin 1.9.24
 - Gradle wrapper (Gradle 8.7) and root project settings
 - Each module includes a minimal `AndroidManifest.xml` and package stub
+- Hilt/Dagger DI graph wired across all modules (Hilt 2.51.1, KSP 1.9.24-1.0.20)
+  - `ChampiApplication` annotated with `@HiltAndroidApp`
+  - `champi.android.hilt` convention plugin applies KSP + Hilt to any module
+  - Placeholder `@Module @InstallIn(SingletonComponent::class)` in `:core`, `:overlay`, `:character`, `:assistant`, `:providers:api`, `:providers:edge`
+  - `Logger` class in `:core` annotated with `@Inject` as a smoke-test injectable
+  - `HiltSmokeTest` instrumented test in `:app` verifies the graph resolves `Logger` from `:core`
+  - `hilt-android-testing` wired for test components via `HiltTestRunner`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("champi.android.application")
+    id("champi.android.hilt")
 }
 
 android {
@@ -8,5 +9,15 @@ android {
         applicationId = "ai.champi.app"
         versionCode = 1
         versionName = "0.1.0"
+        testInstrumentationRunner = "ai.champi.app.HiltTestRunner"
     }
+}
+
+dependencies {
+    implementation(project(":core"))
+
+    androidTestImplementation(libs.hilt.android.testing)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    kspAndroidTest(libs.hilt.compiler)
 }

--- a/app/src/androidTest/kotlin/ai/champi/app/HiltSmokeTest.kt
+++ b/app/src/androidTest/kotlin/ai/champi/app/HiltSmokeTest.kt
@@ -1,0 +1,37 @@
+package ai.champi.app
+
+import ai.champi.core.Logger
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+/**
+ * Verifies that the Hilt DI graph wires [Logger] from :core into :app correctly.
+ * The test passes if the graph compiles and [Logger] is injected without errors.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class HiltSmokeTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var logger: Logger
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun logger_isInjected() {
+        assertNotNull(logger)
+    }
+}

--- a/app/src/androidTest/kotlin/ai/champi/app/HiltTestRunner.kt
+++ b/app/src/androidTest/kotlin/ai/champi/app/HiltTestRunner.kt
@@ -1,0 +1,15 @@
+package ai.champi.app
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+/** Custom [AndroidJUnitRunner] that swaps in [HiltTestApplication] for instrumented tests. */
+class HiltTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(
+        classLoader: ClassLoader,
+        className: String,
+        context: Context,
+    ): Application = super.newApplication(classLoader, HiltTestApplication::class.java.name, context)
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
+        android:name=".ChampiApplication"
         android:label="Champi"
         android:supportsRtl="true" />
 </manifest>

--- a/app/src/main/kotlin/ai/champi/app/ChampiApplication.kt
+++ b/app/src/main/kotlin/ai/champi/app/ChampiApplication.kt
@@ -1,0 +1,7 @@
+package ai.champi.app
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class ChampiApplication : Application()

--- a/assistant/build.gradle.kts
+++ b/assistant/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("champi.android.library")
+    id("champi.android.hilt")
 }
 
 android {

--- a/assistant/src/main/kotlin/ai/champi/assistant/di/AssistantModule.kt
+++ b/assistant/src/main/kotlin/ai/champi/assistant/di/AssistantModule.kt
@@ -1,0 +1,9 @@
+package ai.champi.assistant.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AssistantModule

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -12,6 +12,8 @@ java {
 dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
+    compileOnly(libs.ksp.gradlePlugin)
+    compileOnly(libs.hilt.gradlePlugin)
 }
 
 gradlePlugin {
@@ -23,6 +25,10 @@ gradlePlugin {
         register("androidLibrary") {
             id = "champi.android.library"
             implementationClass = "AndroidLibraryConventionPlugin"
+        }
+        register("androidHilt") {
+            id = "champi.android.hilt"
+            implementationClass = "AndroidHiltConventionPlugin"
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
@@ -1,0 +1,21 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidHiltConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("com.google.devtools.ksp")
+                apply("com.google.dagger.hilt.android")
+            }
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            dependencies {
+                add("implementation", libs.findLibrary("hilt.android").get())
+                add("ksp", libs.findLibrary("hilt.compiler").get())
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.hilt.android) apply false
 }

--- a/character/build.gradle.kts
+++ b/character/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("champi.android.library")
+    id("champi.android.hilt")
 }
 
 android {

--- a/character/src/main/kotlin/ai/champi/character/di/CharacterModule.kt
+++ b/character/src/main/kotlin/ai/champi/character/di/CharacterModule.kt
@@ -1,0 +1,9 @@
+package ai.champi.character.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CharacterModule

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("champi.android.library")
+    id("champi.android.hilt")
 }
 
 android {

--- a/core/src/main/kotlin/ai/champi/core/Logger.kt
+++ b/core/src/main/kotlin/ai/champi/core/Logger.kt
@@ -1,0 +1,18 @@
+package ai.champi.core
+
+import android.util.Log
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Thin wrapper around [android.util.Log] that can be injected throughout the app. */
+@Singleton
+class Logger @Inject constructor() {
+
+    fun d(tag: String, message: String) {
+        Log.d(tag, message)
+    }
+
+    fun e(tag: String, message: String, throwable: Throwable? = null) {
+        Log.e(tag, message, throwable)
+    }
+}

--- a/core/src/main/kotlin/ai/champi/core/di/CoreModule.kt
+++ b/core/src/main/kotlin/ai/champi/core/di/CoreModule.kt
@@ -1,0 +1,9 @@
+package ai.champi.core.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CoreModule

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+android.useAndroidX=true
+android.enableJetifier=false
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+org.gradle.java.home=/home/diva/jdk-17.0.20.1+1
+org.gradle.configuration-cache=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 android.useAndroidX=true
 android.enableJetifier=false
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
-org.gradle.java.home=/home/diva/jdk-17.0.20.1+1
 org.gradle.configuration-cache=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,36 @@
 [versions]
 agp = "8.4.0"
 kotlin = "1.9.24"
+ksp = "1.9.24-1.0.20"
+hilt = "2.51.1"
 core-ktx = "1.13.1"
 compose-bom = "2024.04.01"
+androidx-test-runner = "1.6.1"
+androidx-test-ext-junit = "1.2.1"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 
 [libraries]
 # Build-logic dependencies (referenced by build-logic/convention)
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "symbol-processing-gradle-plugin", version.ref = "ksp" }
+hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
 
 # AndroidX
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+
+# Hilt
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
+
+# Test
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-runner" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }

--- a/overlay/build.gradle.kts
+++ b/overlay/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("champi.android.library")
+    id("champi.android.hilt")
 }
 
 android {

--- a/overlay/src/main/kotlin/ai/champi/overlay/di/OverlayModule.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/di/OverlayModule.kt
@@ -1,0 +1,9 @@
+package ai.champi.overlay.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object OverlayModule

--- a/providers/api/build.gradle.kts
+++ b/providers/api/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("champi.android.library")
+    id("champi.android.hilt")
 }
 
 android {

--- a/providers/api/src/main/kotlin/ai/champi/providers/api/di/ProvidersApiModule.kt
+++ b/providers/api/src/main/kotlin/ai/champi/providers/api/di/ProvidersApiModule.kt
@@ -1,0 +1,9 @@
+package ai.champi.providers.api.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ProvidersApiModule

--- a/providers/edge/build.gradle.kts
+++ b/providers/edge/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("champi.android.library")
+    id("champi.android.hilt")
 }
 
 android {

--- a/providers/edge/src/main/kotlin/ai/champi/providers/edge/di/ProvidersEdgeModule.kt
+++ b/providers/edge/src/main/kotlin/ai/champi/providers/edge/di/ProvidersEdgeModule.kt
@@ -1,0 +1,9 @@
+package ai.champi.providers.edge.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ProvidersEdgeModule


### PR DESCRIPTION
## Summary

- Adds `ChampiApplication` annotated with `@HiltAndroidApp` as the app entry point for the Hilt component tree
- Introduces `champi.android.hilt` convention plugin (KSP 1.9.24-1.0.20 + Hilt 2.51.1) applied to `:app`, `:core`, `:overlay`, `:character`, `:assistant`, `:providers:api`, and `:providers:edge`
- Each module declares a placeholder `@Module @InstallIn(SingletonComponent::class)` so the graph compiles and is ready to receive real bindings
- `Logger` in `:core` is annotated `@Singleton @Inject` as the smoke-test injectable; `HiltSmokeTest` in `:app` verifies the graph resolves it end-to-end
- `hilt-android-testing` + `HiltTestRunner` wired so instrumented test components work from day one

## Test plan

- [x] `./gradlew kspDebugKotlin` completes without Hilt/Dagger component errors
- [x] `./gradlew assembleDebug` produces a debug APK successfully
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` compiles the `HiltSmokeTest` without errors
- [ ] `./gradlew connectedDebugAndroidTest` — run on a device/emulator to execute the smoke test at runtime (requires connected device)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UF4m2pEd9wWYTpEfigz9XE