### PR TITLE
Implement Phase 1: character + interaction (overlay bubble drag/snap/panel/quick-actions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `OverlayPreferencesRepository` (`:core`) — DataStore-backed bubble position and quick-actions geometry persistence
 - Best-effort IME-visibility detection (bubble hides while another app's keyboard is open) via display-frame comparison, since the overlay window is non-focusable and can't receive real `WindowInsets` for it
 - Switched to the Compose BOM (`2026.08.00`) instead of hand-pinning individual `compose-ui`/`compose-material3` versions, after hitting a real cross-artifact version-skew bug; bumped `compileSdk`/`targetSdk` to 37 (required by Compose 1.12.0)
+- Quick-actions targets now render Material Design icons (`androidx.compose.material.icons`) instead of two-letter text abbreviations, in both the radial-arc and edge-rail geometries
 
 ### Fixed
 - `ChampiService.onStartCommand` now also calls `overlayManager.show()` (previously only `onCreate` did), so relaunching the app after dismissing the bubble actually brings it back
 - Overlay dismiss crashed the process: `onDismiss` was calling `hide()` (which removes the view) synchronously from inside that same view's still-executing touch-gesture callback; now deferred via `view.post(...)`
 - Radial quick-actions arc used raw dp magnitudes as pixel offsets in `Modifier.offset { IntOffset(...) }`, rendering the arc ~2.5x smaller than intended and putting targets outside their visible tap area
+- Quick-actions window (`QUICK_ACTIONS_WINDOW_DP`) was 220dp, too small for the 96dp-radius arc of 48dp buttons (needs ~240dp min), so targets overflowed the window and got clipped at the physical screen edge when the bubble was snapped near a corner; bumped to 280dp and confirmed on-device at the worst-case top-left-corner position
 
 ### Added
 - Phase 0 overlay skeleton: `MainActivity` (`:app`) requests `SYSTEM_ALERT_WINDOW` and `POST_NOTIFICATIONS` (Android 13+) via Compose, then starts `ChampiService`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Overlay dismiss crashed the process: `onDismiss` was calling `hide()` (which removes the view) synchronously from inside that same view's still-executing touch-gesture callback; now deferred via `view.post(...)`
 - Radial quick-actions arc used raw dp magnitudes as pixel offsets in `Modifier.offset { IntOffset(...) }`, rendering the arc ~2.5x smaller than intended and putting targets outside their visible tap area
 - Quick-actions window (`QUICK_ACTIONS_WINDOW_DP`) was 220dp, too small for the 96dp-radius arc of 48dp buttons (needs ~240dp min), so targets overflowed the window and got clipped at the physical screen edge when the bubble was snapped near a corner; bumped to 280dp and confirmed on-device at the worst-case top-left-corner position
+- Screen bounds used for clamping (expanded panel height, quick-actions positioning, drag limits, dismiss zone) were computed from `configuration.screenHeightDp`, the *raw* display height — since this window's y-coordinate is relative to the status-bar-inset parent frame, that left ~120px of slack past the real usable bottom, letting content extend into the nav bar and get clipped there; now subtracts status/nav bar insets to get the actual usable height
 
 ### Added
 - Phase 0 overlay skeleton: `MainActivity` (`:app`) requests `SYSTEM_ALERT_WINDOW` and `POST_NOTIFICATIONS` (Android 13+) via Compose, then starts `ChampiService`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Phase 1 character + interaction: single `WindowManager` overlay window that resizes/repositions per state (collapsed bubble / long-press quick-actions / tap-to-expand panel) — the standard "chat heads" technique, since fullscreen touch-passthrough would require the `@hide` `OnComputeInternalInsetsListener` API
+- Drag-to-move with edge-snap on release, and a bottom-center dismiss zone that hides the bubble until the app is relaunched (`OverlayRoot`, `:overlay`)
+- Tap-to-expand bottom panel (60% screen height) with a placeholder "no conversation yet" state; collapses on background tap or swipe-down (`ExpandedPanel`, `:overlay`)
+- Long-press quick-actions surface with both geometries from the open design question implemented (`QuickActionsLayer`, `:overlay`): radial arc (default) and edge rail, selectable via a persisted `OverlayPreferencesRepository` preference once a settings UI exists
+- `CharacterPlaceholder` (`:overlay`) — animated stand-in for the Rive `champi_mushroom` artboard; color/pulse speed vary across all 7 `CharacterState` values
+- `AppState`/`AppStateHolder`/`CharacterState` (`:core`) — shared app state `StateFlow`
+- `OverlayPreferencesRepository` (`:core`) — DataStore-backed bubble position and quick-actions geometry persistence
+- Best-effort IME-visibility detection (bubble hides while another app's keyboard is open) via display-frame comparison, since the overlay window is non-focusable and can't receive real `WindowInsets` for it
+- Switched to the Compose BOM (`2026.08.00`) instead of hand-pinning individual `compose-ui`/`compose-material3` versions, after hitting a real cross-artifact version-skew bug; bumped `compileSdk`/`targetSdk` to 37 (required by Compose 1.12.0)
+
+### Fixed
+- `ChampiService.onStartCommand` now also calls `overlayManager.show()` (previously only `onCreate` did), so relaunching the app after dismissing the bubble actually brings it back
+- Overlay dismiss crashed the process: `onDismiss` was calling `hide()` (which removes the view) synchronously from inside that same view's still-executing touch-gesture callback; now deferred via `view.post(...)`
+- Radial quick-actions arc used raw dp magnitudes as pixel offsets in `Modifier.offset { IntOffset(...) }`, rendering the arc ~2.5x smaller than intended and putting targets outside their visible tap area
+
+### Added
 - Phase 0 overlay skeleton: `MainActivity` (`:app`) requests `SYSTEM_ALERT_WINDOW` and `POST_NOTIFICATIONS` (Android 13+) via Compose, then starts `ChampiService`
 - `ChampiService` (`:app`) — `specialUse` foreground service with a persistent notification, shows/hides the overlay via `OverlayManager`
 - `OverlayManager` + `OverlayLifecycleOwner` (`:overlay`) — `WindowManager`-attached `ComposeView` with a manually-wired `LifecycleOwner`/`ViewModelStoreOwner`/`SavedStateRegistryOwner`, rendering a static 56dp placeholder bubble
 - `BootReceiver` (`:app`) restarts `ChampiService` after reboot if the overlay permission is still granted
-- `champi.android.compose` convention plugin wires Jetpack Compose (BOM-free, pinned `compose-ui`/`compose-material3` versions) into `:app` and `:overlay`
+- `champi.android.compose` convention plugin wires Jetpack Compose (Compose BOM) into `:app` and `:overlay`
 - GitHub Actions workflow (`android-ci.yml`): runs `./gradlew lint` and `./gradlew assembleDebug` on every PR to `main`
 
 ### Added

--- a/app/src/main/kotlin/ai/champi/app/ChampiService.kt
+++ b/app/src/main/kotlin/ai/champi/app/ChampiService.kt
@@ -27,7 +27,12 @@ class ChampiService : Service() {
         overlayManager.show()
     }
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_STICKY
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Re-shows the bubble if the user dragged it into the dismiss zone; show() is a no-op
+        // otherwise since it already checks whether the overlay view exists.
+        overlayManager.show()
+        return START_STICKY
+    }
 
     override fun onDestroy() {
         overlayManager.hide()

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -10,10 +10,10 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 apply("com.android.application")
             }
             extensions.configure<ApplicationExtension> {
-                compileSdk = 35
+                compileSdk = 37
                 defaultConfig {
                     minSdk = 29
-                    targetSdk = 35
+                    targetSdk = 37
                 }
                 compileOptions {
                     sourceCompatibility = org.gradle.api.JavaVersion.VERSION_17

--- a/build-logic/convention/src/main/kotlin/AndroidComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidComposeConventionPlugin.kt
@@ -25,10 +25,12 @@ class AndroidComposeConventionPlugin : Plugin<Project> {
 
             val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
             dependencies {
+                add("implementation", platform(libs.findLibrary("androidx-compose-bom").get()))
                 add("implementation", libs.findLibrary("androidx-compose-ui").get())
                 add("implementation", libs.findLibrary("androidx-compose-ui-tooling-preview").get())
                 add("debugImplementation", libs.findLibrary("androidx-compose-ui-tooling").get())
                 add("implementation", libs.findLibrary("androidx-compose-material3").get())
+                add("implementation", libs.findLibrary("androidx-compose-animation").get())
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/AndroidComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidComposeConventionPlugin.kt
@@ -31,6 +31,7 @@ class AndroidComposeConventionPlugin : Plugin<Project> {
                 add("debugImplementation", libs.findLibrary("androidx-compose-ui-tooling").get())
                 add("implementation", libs.findLibrary("androidx-compose-material3").get())
                 add("implementation", libs.findLibrary("androidx-compose-animation").get())
+                add("implementation", libs.findLibrary("androidx-compose-material-icons-extended").get())
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -10,7 +10,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 apply("com.android.library")
             }
             extensions.configure<LibraryExtension> {
-                compileSdk = 35
+                compileSdk = 37
                 defaultConfig {
                     minSdk = 29
                 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,3 +6,8 @@ plugins {
 android {
     namespace = "ai.champi.core"
 }
+
+dependencies {
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.kotlinx.coroutines.android)
+}

--- a/core/src/main/kotlin/ai/champi/core/overlay/OverlayPreferencesRepository.kt
+++ b/core/src/main/kotlin/ai/champi/core/overlay/OverlayPreferencesRepository.kt
@@ -1,0 +1,58 @@
+package ai.champi.core.overlay
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Plain (non-Compose) pixel offset, so `:core` doesn't need a dependency on Compose UI. */
+data class BubbleOffset(val x: Int, val y: Int)
+
+private val Context.overlayDataStore: DataStore<Preferences> by preferencesDataStore(name = "overlay_prefs")
+
+/** Persists bubble position and the quick-actions geometry choice across process restarts. */
+@Singleton
+class OverlayPreferencesRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val dataStore get() = context.overlayDataStore
+
+    val bubbleOffset: Flow<BubbleOffset> = dataStore.data.map { prefs ->
+        BubbleOffset(
+            x = prefs[KEY_BUBBLE_X] ?: 0,
+            y = prefs[KEY_BUBBLE_Y] ?: DEFAULT_BUBBLE_Y,
+        )
+    }
+
+    suspend fun saveBubbleOffset(offset: BubbleOffset) {
+        dataStore.edit { prefs ->
+            prefs[KEY_BUBBLE_X] = offset.x
+            prefs[KEY_BUBBLE_Y] = offset.y
+        }
+    }
+
+    val quickActionGeometry: Flow<QuickActionGeometry> = dataStore.data.map { prefs ->
+        prefs[KEY_QUICK_ACTION_GEOMETRY]
+            ?.let { name -> runCatching { QuickActionGeometry.valueOf(name) }.getOrNull() }
+            ?: QuickActionGeometry.RADIAL_ARC
+    }
+
+    suspend fun setQuickActionGeometry(geometry: QuickActionGeometry) {
+        dataStore.edit { it[KEY_QUICK_ACTION_GEOMETRY] = geometry.name }
+    }
+
+    private companion object {
+        val KEY_BUBBLE_X = intPreferencesKey("bubble_x")
+        val KEY_BUBBLE_Y = intPreferencesKey("bubble_y")
+        val KEY_QUICK_ACTION_GEOMETRY = stringPreferencesKey("quick_action_geometry")
+        const val DEFAULT_BUBBLE_Y = 600
+    }
+}

--- a/core/src/main/kotlin/ai/champi/core/overlay/QuickAction.kt
+++ b/core/src/main/kotlin/ai/champi/core/overlay/QuickAction.kt
@@ -1,0 +1,15 @@
+package ai.champi.core.overlay
+
+/** The four long-press quick actions from the overlay bubble (phase 1: visual only, stubs). */
+enum class QuickAction {
+    MUTE_MIC,
+    PUSH_TO_TALK,
+    SLEEP,
+    SETTINGS,
+}
+
+/** Quick-actions surface geometry — both are implemented; selection persists via [OverlayPreferencesRepository]. */
+enum class QuickActionGeometry {
+    RADIAL_ARC,
+    EDGE_RAIL,
+}

--- a/core/src/main/kotlin/ai/champi/core/state/AppState.kt
+++ b/core/src/main/kotlin/ai/champi/core/state/AppState.kt
@@ -1,0 +1,13 @@
+package ai.champi.core.state
+
+data class ConversationEntry(
+    val id: String,
+    val text: String,
+    val fromUser: Boolean,
+)
+
+data class AppState(
+    val characterState: CharacterState = CharacterState.IDLE,
+    val conversation: List<ConversationEntry> = emptyList(),
+    val audioLevel: Float = 0f,
+)

--- a/core/src/main/kotlin/ai/champi/core/state/AppStateHolder.kt
+++ b/core/src/main/kotlin/ai/champi/core/state/AppStateHolder.kt
@@ -1,0 +1,26 @@
+package ai.champi.core.state
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Single source of truth for [AppState], shared by `:overlay`, `:character` and `:assistant`. */
+@Singleton
+class AppStateHolder @Inject constructor() {
+    private val _state = MutableStateFlow(AppState())
+    val state: StateFlow<AppState> = _state
+
+    fun setCharacterState(characterState: CharacterState) {
+        _state.update { it.copy(characterState = characterState) }
+    }
+
+    fun setAudioLevel(level: Float) {
+        _state.update { it.copy(audioLevel = level) }
+    }
+
+    fun appendConversationEntry(entry: ConversationEntry) {
+        _state.update { it.copy(conversation = it.conversation + entry) }
+    }
+}

--- a/core/src/main/kotlin/ai/champi/core/state/CharacterState.kt
+++ b/core/src/main/kotlin/ai/champi/core/state/CharacterState.kt
@@ -1,0 +1,12 @@
+package ai.champi.core.state
+
+/** The seven visual/behavioral states the character (Rive artboard) can be driven into. */
+enum class CharacterState {
+    IDLE,
+    LISTENING,
+    THINKING,
+    SPEAKING,
+    NOTIFYING,
+    ERROR,
+    SLEEPING,
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,11 +4,12 @@ kotlin = "2.3.0"
 ksp = "2.3.11"
 hilt = "2.60.1"
 core-ktx = "1.13.1"
-compose-ui = "1.7.6"
-compose-material3 = "1.3.1"
+compose-bom = "2026.08.00"
 androidx-activity = "1.9.3"
 androidx-lifecycle = "2.8.7"
 androidx-savedstate = "1.2.1"
+androidx-datastore = "1.1.1"
+kotlinx-coroutines = "1.9.0"
 androidx-test-runner = "1.6.1"
 androidx-test-ext-junit = "1.2.1"
 
@@ -29,14 +30,18 @@ hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-p
 
 # AndroidX
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
-androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose-ui" }
-androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose-ui" }
-androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose-ui" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "compose-material3" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 androidx-savedstate-ktx = { group = "androidx.savedstate", name = "savedstate-ktx", version.ref = "androidx-savedstate" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidx-datastore" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 
 # Hilt
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }

--- a/overlay/build.gradle.kts
+++ b/overlay/build.gradle.kts
@@ -9,7 +9,10 @@ android {
 }
 
 dependencies {
+    implementation(project(":core"))
+
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.savedstate.ktx)
+    implementation(libs.kotlinx.coroutines.android)
 }

--- a/overlay/src/main/kotlin/ai/champi/overlay/CharacterPlaceholder.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/CharacterPlaceholder.kt
@@ -1,0 +1,65 @@
+package ai.champi.overlay
+
+import ai.champi.core.state.CharacterState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Stand-in for the Rive `champi_mushroom` artboard (see phase-1 spec) until that asset lands.
+ * Color and pulse speed vary per [CharacterState] so the seven states read as visually distinct.
+ */
+@Composable
+fun CharacterPlaceholder(state: CharacterState, size: Dp, modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "breathing")
+    val scale by transition.animateFloat(
+        initialValue = 0.9f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = pulseDurationMs(state), easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "scale",
+    )
+    Box(
+        modifier = modifier
+            .size(size)
+            .scale(scale)
+            .clip(CircleShape)
+            .background(colorFor(state)),
+    )
+}
+
+private fun pulseDurationMs(state: CharacterState): Int = when (state) {
+    CharacterState.IDLE -> 2200
+    CharacterState.LISTENING -> 900
+    CharacterState.THINKING -> 600
+    CharacterState.SPEAKING -> 450
+    CharacterState.NOTIFYING -> 350
+    CharacterState.ERROR -> 250
+    CharacterState.SLEEPING -> 3500
+}
+
+private fun colorFor(state: CharacterState): Color = when (state) {
+    CharacterState.IDLE -> Color(0xFF6750A4)
+    CharacterState.LISTENING -> Color(0xFF3D8BFF)
+    CharacterState.THINKING -> Color(0xFFB388FF)
+    CharacterState.SPEAKING -> Color(0xFF00C9A7)
+    CharacterState.NOTIFYING -> Color(0xFFFFB300)
+    CharacterState.ERROR -> Color(0xFFE53935)
+    CharacterState.SLEEPING -> Color(0xFF546E7A)
+}

--- a/overlay/src/main/kotlin/ai/champi/overlay/ExpandedPanel.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/ExpandedPanel.kt
@@ -1,0 +1,89 @@
+package ai.champi.overlay
+
+import ai.champi.core.state.AppState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+
+private const val SWIPE_DOWN_DISMISS_THRESHOLD_DP = 48
+
+/**
+ * Empty conversation panel shown when the bubble is tapped (phase 1: no real transcript yet).
+ * There's no "tap outside" region to detect (see [OverlayRoot]'s comment on why), so this
+ * collapses on a background tap or a swipe-down instead.
+ */
+@Composable
+fun ExpandedPanel(appState: AppState, onCollapse: () -> Unit, modifier: Modifier = Modifier) {
+    val density = androidx.compose.ui.platform.LocalDensity.current
+    val dismissThresholdPx = with(density) { SWIPE_DOWN_DISMISS_THRESHOLD_DP.dp.toPx() }
+
+    Surface(
+        modifier = modifier
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) { onCollapse() }
+            .pointerInput(Unit) {
+                var totalDragY = 0f
+                detectVerticalDragGestures(
+                    onDragStart = { totalDragY = 0f },
+                    onDragEnd = { if (totalDragY > dismissThresholdPx) onCollapse() },
+                ) { change, dragAmount ->
+                    change.consume()
+                    totalDragY += dragAmount
+                }
+            },
+        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 8.dp,
+    ) {
+        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .size(width = 32.dp, height = 4.dp)
+                    .background(MaterialTheme.colorScheme.onSurfaceVariant, CircleShape),
+            )
+            Spacer(Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                CharacterPlaceholder(state = appState.characterState, size = 96.dp)
+                Text("Champi", style = MaterialTheme.typography.titleMedium)
+            }
+            Spacer(Modifier.height(16.dp))
+            if (appState.conversation.isEmpty()) {
+                Box(
+                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        "No conversation yet.",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    items(appState.conversation) { entry -> Text(entry.text) }
+                }
+            }
+        }
+    }
+}

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayManager.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayManager.kt
@@ -1,42 +1,46 @@
 package ai.champi.overlay
 
+import ai.champi.core.overlay.OverlayPreferencesRepository
+import ai.champi.core.state.AppStateHolder
 import android.content.Context
 import android.graphics.PixelFormat
 import android.view.Gravity
 import android.view.WindowManager
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.unit.dp
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/** Adds/removes the static placeholder bubble overlay via [WindowManager]. */
+/**
+ * Owns the single overlay window. [OverlayRoot] renders bubble/panel/quick-actions content and
+ * reports the [WindowSpec] it currently needs; this class is the only thing that talks to
+ * [WindowManager], resizing/repositioning that one window to match — the same technique classic
+ * "chat heads" overlays use, since fullscreen-window-with-touch-region-masking requires a
+ * `@hide` platform API ([android.view.ViewTreeObserver.OnComputeInternalInsetsListener]) that
+ * isn't available in the public SDK.
+ */
 @Singleton
 class OverlayManager @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val appStateHolder: AppStateHolder,
+    private val preferences: OverlayPreferencesRepository,
 ) {
     private val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
 
     private var composeView: ComposeView? = null
     private var lifecycleOwner: OverlayLifecycleOwner? = null
+    private var scope: CoroutineScope? = null
 
     fun show() {
         if (composeView != null) return
 
         val owner = OverlayLifecycleOwner()
-        val view = ComposeView(context).apply {
-            setContent { BubbleOverlay() }
-        }
-        owner.attachToView(view)
-        owner.onStart()
+        val overlayScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        scope = overlayScope
 
         val layoutParams = WindowManager.LayoutParams(
             WindowManager.LayoutParams.WRAP_CONTENT,
@@ -46,11 +50,30 @@ class OverlayManager @Inject constructor(
                 WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
             PixelFormat.TRANSLUCENT,
-        ).apply {
-            gravity = Gravity.TOP or Gravity.START
-            x = 0
-            y = 200
+        ).apply { gravity = Gravity.TOP or Gravity.START }
+
+        val view = ComposeView(context)
+        view.setContent {
+            OverlayRoot(
+                appStateHolder = appStateHolder,
+                preferences = preferences,
+                scope = overlayScope,
+                // Deferred via post(): onDismiss fires from inside the bubble's own touch-event
+                // dispatch (the drag-end callback), so removing that same view synchronously
+                // here would tear down the view hierarchy mid-dispatch.
+                onDismiss = { view.post(::hide) },
+                onWindowSpecChanged = { spec ->
+                    layoutParams.width = spec.widthPx
+                    layoutParams.height = spec.heightPx
+                    layoutParams.x = spec.xPx
+                    layoutParams.y = spec.yPx
+                    layoutParams.gravity = spec.gravity
+                    runCatching { windowManager.updateViewLayout(view, layoutParams) }
+                },
+            )
         }
+        owner.attachToView(view)
+        owner.onStart()
 
         windowManager.addView(view, layoutParams)
         composeView = view
@@ -58,19 +81,11 @@ class OverlayManager @Inject constructor(
     }
 
     fun hide() {
-        composeView?.let { windowManager.removeView(it) }
+        composeView?.let { runCatching { windowManager.removeView(it) } }
         lifecycleOwner?.onDestroy()
+        scope?.cancel()
         composeView = null
         lifecycleOwner = null
+        scope = null
     }
-}
-
-@Composable
-private fun BubbleOverlay() {
-    Box(
-        modifier = Modifier
-            .size(56.dp)
-            .clip(CircleShape)
-            .background(Color(0xFF6750A4)),
-    )
 }

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
@@ -1,0 +1,269 @@
+package ai.champi.overlay
+
+import ai.champi.core.overlay.BubbleOffset
+import ai.champi.core.overlay.OverlayPreferencesRepository
+import ai.champi.core.overlay.QuickAction
+import ai.champi.core.overlay.QuickActionGeometry
+import ai.champi.core.state.AppStateHolder
+import ai.champi.core.state.CharacterState
+import android.graphics.Rect as AndroidRect
+import android.os.SystemClock
+import android.view.Gravity
+import android.view.ViewTreeObserver
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+private const val LONG_PRESS_TIMEOUT_MS = 400L
+private const val PEEK_IDLE_TIMEOUT_MS = 3 * 60 * 1000L
+private const val BUBBLE_SIZE_DP = 56
+private const val PEEK_VISIBLE_DP = 28
+private const val QUICK_ACTIONS_WINDOW_DP = 220
+private const val EXPANDED_HEIGHT_FRACTION = 0.6f
+
+/**
+ * Everything the overlay bubble/panel/quick-actions renders, plus the state machine driving it.
+ * The overlay window itself is sized to whatever's currently visible (see [OverlayManager]) —
+ * there is no fullscreen touch-passthrough trick here, since the platform API for it
+ * (`ViewTreeObserver.OnComputeInternalInsetsListener`) is `@hide` and not in the public SDK.
+ */
+@Composable
+internal fun OverlayRoot(
+    appStateHolder: AppStateHolder,
+    preferences: OverlayPreferencesRepository,
+    scope: CoroutineScope,
+    onDismiss: () -> Unit,
+    onWindowSpecChanged: (WindowSpec) -> Unit,
+) {
+    val appState by appStateHolder.state.collectAsState()
+    val density = LocalDensity.current
+    val view = LocalView.current
+    val configuration = LocalConfiguration.current
+
+    var mode by remember { mutableStateOf(OverlayMode.COLLAPSED) }
+    var bubbleOffset by remember { mutableStateOf(IntOffset(0, 600)) }
+    var peeked by remember { mutableStateOf(false) }
+    var geometry by remember { mutableStateOf(QuickActionGeometry.RADIAL_ARC) }
+    var imeVisible by remember { mutableStateOf(false) }
+
+    val screenWidthPx = with(density) { configuration.screenWidthDp.dp.roundToPx() }
+    val screenHeightPx = with(density) { configuration.screenHeightDp.dp.roundToPx() }
+    val bubblePx = with(density) { BUBBLE_SIZE_DP.dp.roundToPx() }
+    val peekVisiblePx = with(density) { PEEK_VISIBLE_DP.dp.roundToPx() }
+    val quickActionsPx = with(density) { QUICK_ACTIONS_WINDOW_DP.dp.roundToPx() }
+    val expandedHeightDp = configuration.screenHeightDp * EXPANDED_HEIGHT_FRACTION
+    val expandedHeightPx = with(density) { expandedHeightDp.dp.roundToPx() }
+    val isAtStartEdge = bubbleOffset.x < (screenWidthPx - bubblePx) / 2
+
+    LaunchedEffect(Unit) {
+        preferences.bubbleOffset.collectLatest { bubbleOffset = IntOffset(it.x, it.y) }
+    }
+    LaunchedEffect(Unit) {
+        preferences.quickActionGeometry.collectLatest { geometry = it }
+    }
+
+    // Best-effort keyboard detection: this overlay window is FLAG_NOT_FOCUSABLE so it never
+    // receives WindowInsets for another app's IME. Comparing the visible display frame is the
+    // same heuristic long-standing floating-bubble apps use; accuracy varies by OEM.
+    DisposableEffect(view) {
+        val listener = ViewTreeObserver.OnGlobalLayoutListener {
+            val rect = AndroidRect()
+            view.getWindowVisibleDisplayFrame(rect)
+            imeVisible = (screenHeightPx - rect.bottom) > screenHeightPx * 0.15
+        }
+        view.viewTreeObserver.addOnGlobalLayoutListener(listener)
+        onDispose { view.viewTreeObserver.removeOnGlobalLayoutListener(listener) }
+    }
+
+    LaunchedEffect(bubbleOffset, mode) {
+        peeked = false
+        if (mode == OverlayMode.COLLAPSED) {
+            delay(PEEK_IDLE_TIMEOUT_MS)
+            peeked = true
+        }
+    }
+
+    val windowSpec = remember(mode, bubbleOffset, peeked, isAtStartEdge, screenWidthPx, screenHeightPx) {
+        when (mode) {
+            OverlayMode.EXPANDED -> WindowSpec(
+                widthPx = screenWidthPx,
+                heightPx = expandedHeightPx,
+                xPx = 0,
+                yPx = 0,
+                gravity = Gravity.BOTTOM or Gravity.START,
+            )
+
+            OverlayMode.QUICK_ACTIONS -> {
+                val x = if (isAtStartEdge) bubbleOffset.x else bubbleOffset.x - (quickActionsPx - bubblePx)
+                val y = (bubbleOffset.y - (quickActionsPx - bubblePx) / 2)
+                    .coerceIn(0, (screenHeightPx - quickActionsPx).coerceAtLeast(0))
+                WindowSpec(
+                    widthPx = quickActionsPx,
+                    heightPx = quickActionsPx,
+                    xPx = x.coerceIn(0, (screenWidthPx - quickActionsPx).coerceAtLeast(0)),
+                    yPx = y,
+                    gravity = Gravity.TOP or Gravity.START,
+                )
+            }
+
+            OverlayMode.COLLAPSED -> {
+                val x = when {
+                    !peeked -> bubbleOffset.x
+                    isAtStartEdge -> -(bubblePx - peekVisiblePx)
+                    else -> screenWidthPx - peekVisiblePx
+                }
+                WindowSpec(bubblePx, bubblePx, x, bubbleOffset.y, Gravity.TOP or Gravity.START)
+            }
+        }
+    }
+
+    SideEffect { if (!imeVisible) onWindowSpecChanged(windowSpec) }
+
+    if (imeVisible) return
+
+    when (mode) {
+        // There's no "tap outside the panel" region to detect here: this window covers only the
+        // bottom EXPANDED_HEIGHT_FRACTION of the screen (see the class doc on why — no fullscreen
+        // touch-passthrough trick is available), so the panel already fills 100% of it. Collapse
+        // is reachable within our own bounds via a background tap or swipe-down instead.
+        OverlayMode.EXPANDED -> ExpandedPanel(
+            appState = appState,
+            onCollapse = { mode = OverlayMode.COLLAPSED },
+            modifier = Modifier.fillMaxWidth().height(expandedHeightDp.dp),
+        )
+
+        OverlayMode.QUICK_ACTIONS -> Box(modifier = Modifier.size(QUICK_ACTIONS_WINDOW_DP.dp)) {
+            QuickActionsLayer(
+                visible = true,
+                geometry = geometry,
+                anchorEdgeIsStart = isAtStartEdge,
+                onSelect = { action ->
+                    mode = OverlayMode.COLLAPSED
+                    if (action == QuickAction.SLEEP) appStateHolder.setCharacterState(CharacterState.SLEEPING)
+                },
+                modifier = Modifier.align(Alignment.Center),
+            )
+            Box(modifier = Modifier.align(if (isAtStartEdge) Alignment.TopStart else Alignment.TopEnd)) {
+                CharacterPlaceholder(state = appState.characterState, size = BUBBLE_SIZE_DP.dp)
+            }
+        }
+
+        OverlayMode.COLLAPSED -> Box(
+            modifier = Modifier
+                .size(BUBBLE_SIZE_DP.dp)
+                .pointerInput(Unit) {
+                    detectBubbleGestures(
+                        onTouchStart = { peeked = false },
+                        onDrag = { delta ->
+                            bubbleOffset = IntOffset(
+                                (bubbleOffset.x + delta.x.roundToInt())
+                                    .coerceIn(0, (screenWidthPx - bubblePx).coerceAtLeast(0)),
+                                (bubbleOffset.y + delta.y.roundToInt())
+                                    .coerceIn(0, (screenHeightPx - bubblePx).coerceAtLeast(0)),
+                            )
+                        },
+                        onDragEnd = {
+                            val centerX = bubbleOffset.x + bubblePx / 2
+                            val centerY = bubbleOffset.y + bubblePx / 2
+                            val inDismissZone = centerY > screenHeightPx - bubblePx * 2 &&
+                                centerX in (screenWidthPx / 2 - bubblePx)..(screenWidthPx / 2 + bubblePx)
+                            if (inDismissZone) {
+                                onDismiss()
+                            } else {
+                                val snappedX = if (centerX < screenWidthPx / 2) 0 else screenWidthPx - bubblePx
+                                bubbleOffset = bubbleOffset.copy(x = snappedX)
+                                scope.launch { preferences.saveBubbleOffset(BubbleOffset(snappedX, bubbleOffset.y)) }
+                            }
+                        },
+                        onTap = { mode = OverlayMode.EXPANDED },
+                        onLongPress = { mode = OverlayMode.QUICK_ACTIONS },
+                    )
+                },
+        ) {
+            CharacterPlaceholder(state = appState.characterState, size = BUBBLE_SIZE_DP.dp)
+        }
+    }
+}
+
+/**
+ * Disambiguates tap / drag / long-press on a single pointer stream. Compose's built-in
+ * `detectTapGestures`/`detectDragGestures` can't be combined on one target since both would
+ * race for the same down event, so this races a long-press timer against incoming pointer
+ * events by hand.
+ */
+private suspend fun PointerInputScope.detectBubbleGestures(
+    onTouchStart: () -> Unit,
+    onDrag: (Offset) -> Unit,
+    onDragEnd: () -> Unit,
+    onTap: () -> Unit,
+    onLongPress: () -> Unit,
+) = awaitEachGesture {
+    val down = awaitFirstDown(requireUnconsumed = false)
+    onTouchStart()
+    val downUptimeMillis = SystemClock.uptimeMillis()
+    var dragging = false
+    var longPressFired = false
+    var totalDrag = Offset.Zero
+    val slop = viewConfiguration.touchSlop
+
+    while (true) {
+        // AwaitPointerEventScope is @RestrictsSuspension, so a long-press timer can't run as a
+        // separate launched coroutine racing this loop (as detectTapGestures-style code usually
+        // would) — instead, wrap the *wait for the next event* itself in a timeout: null means
+        // the finger has been held still for the remaining budget, i.e. a long press.
+        val remaining = LONG_PRESS_TIMEOUT_MS - (SystemClock.uptimeMillis() - downUptimeMillis)
+        val event = if (!dragging && !longPressFired && remaining > 0) {
+            withTimeoutOrNull(remaining) { awaitPointerEvent() }
+        } else {
+            awaitPointerEvent()
+        }
+        if (event == null) {
+            longPressFired = true
+            onLongPress()
+            continue
+        }
+        val change = event.changes.firstOrNull { it.id == down.id } ?: break
+        if (!change.pressed) {
+            if (dragging) onDragEnd() else if (!longPressFired) onTap()
+            break
+        }
+        val delta = change.positionChange()
+        totalDrag += delta
+        if (!dragging && totalDrag.getDistance() > slop) {
+            dragging = true
+        }
+        if (dragging) {
+            change.consume()
+            onDrag(delta)
+        }
+    }
+}

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
@@ -47,7 +47,8 @@ private const val LONG_PRESS_TIMEOUT_MS = 400L
 private const val PEEK_IDLE_TIMEOUT_MS = 3 * 60 * 1000L
 private const val BUBBLE_SIZE_DP = 56
 private const val PEEK_VISIBLE_DP = 28
-private const val QUICK_ACTIONS_WINDOW_DP = 220
+// Radial arc: 96 dp radius + 48 dp button diameter means ~240 dp min; use 280 dp to avoid edge clipping
+private const val QUICK_ACTIONS_WINDOW_DP = 280
 private const val EXPANDED_HEIGHT_FRACTION = 0.6f
 
 /**
@@ -123,6 +124,11 @@ internal fun OverlayRoot(
             )
 
             OverlayMode.QUICK_ACTIONS -> {
+                // Keep the bubble's edge of the window fixed to the bubble (so the arc, which
+                // sweeps *away* from whichever edge the bubble is snapped to, always sweeps into
+                // the screen rather than off it) and only clamp the far edge/vertical position —
+                // the window is intentionally larger than the arc's reach (see QUICK_ACTIONS_WINDOW_DP)
+                // so this alone keeps every button on-screen without needing the arc off-center.
                 val x = if (isAtStartEdge) bubbleOffset.x else bubbleOffset.x - (quickActionsPx - bubblePx)
                 val y = (bubbleOffset.y - (quickActionsPx - bubblePx) / 2)
                     .coerceIn(0, (screenHeightPx - quickActionsPx).coerceAtLeast(0))

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
@@ -76,13 +76,27 @@ internal fun OverlayRoot(
     var geometry by remember { mutableStateOf(QuickActionGeometry.RADIAL_ARC) }
     var imeVisible by remember { mutableStateOf(false) }
 
+    // configuration.screenHeightDp is the *raw* display height, but this window's y-coordinate
+    // is relative to the status-bar-inset parent frame WindowManager gives it — clamping against
+    // the raw height left room for the window to extend past the real bottom of that frame, into
+    // where the nav bar sits, clipping quick-actions targets there. Subtract both system bar
+    // insets (looked up the classic way, since this overlay has no Activity decor to ask via
+    // WindowInsets) to get the actual usable bound.
     val screenWidthPx = with(density) { configuration.screenWidthDp.dp.roundToPx() }
-    val screenHeightPx = with(density) { configuration.screenHeightDp.dp.roundToPx() }
+    val rawScreenHeightPx = with(density) { configuration.screenHeightDp.dp.roundToPx() }
+    val systemBarInsetsPx = remember(view) {
+        val resources = view.resources
+        fun barHeight(name: String): Int {
+            val id = resources.getIdentifier(name, "dimen", "android")
+            return if (id > 0) resources.getDimensionPixelSize(id) else 0
+        }
+        barHeight("status_bar_height") + barHeight("navigation_bar_height")
+    }
+    val screenHeightPx = (rawScreenHeightPx - systemBarInsetsPx).coerceAtLeast(0)
     val bubblePx = with(density) { BUBBLE_SIZE_DP.dp.roundToPx() }
     val peekVisiblePx = with(density) { PEEK_VISIBLE_DP.dp.roundToPx() }
     val quickActionsPx = with(density) { QUICK_ACTIONS_WINDOW_DP.dp.roundToPx() }
-    val expandedHeightDp = configuration.screenHeightDp * EXPANDED_HEIGHT_FRACTION
-    val expandedHeightPx = with(density) { expandedHeightDp.dp.roundToPx() }
+    val expandedHeightPx = (screenHeightPx * EXPANDED_HEIGHT_FRACTION).roundToInt()
     val isAtStartEdge = bubbleOffset.x < (screenWidthPx - bubblePx) / 2
 
     LaunchedEffect(Unit) {
@@ -164,7 +178,7 @@ internal fun OverlayRoot(
         OverlayMode.EXPANDED -> ExpandedPanel(
             appState = appState,
             onCollapse = { mode = OverlayMode.COLLAPSED },
-            modifier = Modifier.fillMaxWidth().height(expandedHeightDp.dp),
+            modifier = Modifier.fillMaxWidth().height(with(density) { expandedHeightPx.toDp() }),
         )
 
         OverlayMode.QUICK_ACTIONS -> Box(modifier = Modifier.size(QUICK_ACTIONS_WINDOW_DP.dp)) {

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayWindow.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayWindow.kt
@@ -1,0 +1,12 @@
+package ai.champi.overlay
+
+internal enum class OverlayMode { COLLAPSED, QUICK_ACTIONS, EXPANDED }
+
+/** Desired `WindowManager.LayoutParams` geometry for the single overlay window, in pixels. */
+internal data class WindowSpec(
+    val widthPx: Int,
+    val heightPx: Int,
+    val xPx: Int,
+    val yPx: Int,
+    val gravity: Int,
+)

--- a/overlay/src/main/kotlin/ai/champi/overlay/QuickActionsLayer.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/QuickActionsLayer.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,6 +19,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MicOff
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -25,15 +32,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import kotlin.math.cos
 import kotlin.math.sin
 
+private data class QuickActionSpec(val action: QuickAction, val icon: ImageVector, val label: String)
+
 private val ACTIONS = listOf(
-    QuickAction.MUTE_MIC to "Mute",
-    QuickAction.PUSH_TO_TALK to "Talk",
-    QuickAction.SLEEP to "Sleep",
-    QuickAction.SETTINGS to "Settings",
+    QuickActionSpec(QuickAction.MUTE_MIC, Icons.Filled.MicOff, "Mute mic"),
+    QuickActionSpec(QuickAction.PUSH_TO_TALK, Icons.Filled.Mic, "Push to talk"),
+    QuickActionSpec(QuickAction.SLEEP, Icons.Filled.Bedtime, "Sleep"),
+    QuickActionSpec(QuickAction.SETTINGS, Icons.Filled.Settings, "Settings"),
 )
 
 /**
@@ -68,17 +78,18 @@ private fun RadialArcActions(anchorEdgeIsStart: Boolean, onSelect: (QuickAction)
     val radiusDp = 96.dp
     Box(modifier = Modifier.size(radiusDp * 2)) {
         val (startAngle, endAngle) = if (anchorEdgeIsStart) -60f to 60f else 120f to 240f
-        ACTIONS.forEachIndexed { index, (action, label) ->
+        ACTIONS.forEachIndexed { index, spec ->
             val angleDeg = startAngle + index * (endAngle - startAngle) / (ACTIONS.size - 1)
             val angleRad = Math.toRadians(angleDeg.toDouble())
             val offsetX = (radiusDp.value * cos(angleRad)).dp
             val offsetY = (radiusDp.value * sin(angleRad)).dp
             QuickActionTarget(
-                label = label,
+                icon = spec.icon,
+                contentDescription = spec.label,
                 modifier = Modifier
                     .align(Alignment.Center)
                     .offset(x = offsetX, y = offsetY)
-                    .clickable { onSelect(action) },
+                    .clickable { onSelect(spec.action) },
             )
         }
     }
@@ -92,16 +103,18 @@ private fun EdgeRailActions(onSelect: (QuickAction) -> Unit) {
         tonalElevation = 4.dp,
     ) {
         Column {
-            ACTIONS.forEach { (action, label) ->
+            ACTIONS.forEach { spec ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(48.dp)
-                        .clickable { onSelect(action) }
+                        .clickable { onSelect(spec.action) }
                         .padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(label, color = MaterialTheme.colorScheme.onSurface)
+                    Icon(spec.icon, contentDescription = null, tint = MaterialTheme.colorScheme.onSurface)
+                    Text(spec.label, color = MaterialTheme.colorScheme.onSurface)
                 }
             }
         }
@@ -109,14 +122,14 @@ private fun EdgeRailActions(onSelect: (QuickAction) -> Unit) {
 }
 
 @Composable
-private fun QuickActionTarget(label: String, modifier: Modifier = Modifier) {
+private fun QuickActionTarget(icon: ImageVector, contentDescription: String, modifier: Modifier = Modifier) {
     Surface(
         modifier = modifier.size(48.dp),
         shape = CircleShape,
         color = MaterialTheme.colorScheme.primary,
     ) {
         Box(contentAlignment = Alignment.Center) {
-            Text(label.take(2), color = Color.White)
+            Icon(icon, contentDescription = contentDescription, tint = Color.White)
         }
     }
 }

--- a/overlay/src/main/kotlin/ai/champi/overlay/QuickActionsLayer.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/QuickActionsLayer.kt
@@ -1,0 +1,122 @@
+package ai.champi.overlay
+
+import ai.champi.core.overlay.QuickAction
+import ai.champi.core.overlay.QuickActionGeometry
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlin.math.cos
+import kotlin.math.sin
+
+private val ACTIONS = listOf(
+    QuickAction.MUTE_MIC to "Mute",
+    QuickAction.PUSH_TO_TALK to "Talk",
+    QuickAction.SLEEP to "Sleep",
+    QuickAction.SETTINGS to "Settings",
+)
+
+/**
+ * Long-press quick-actions surface. Both geometries from the phase-1 spec's open question are
+ * implemented; [geometry] (persisted in [ai.champi.core.overlay.OverlayPreferencesRepository])
+ * picks which one renders — there's no settings UI yet to switch it, that lands with the real
+ * settings screen.
+ */
+@Composable
+fun QuickActionsLayer(
+    visible: Boolean,
+    geometry: QuickActionGeometry,
+    anchorEdgeIsStart: Boolean,
+    onSelect: (QuickAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + scaleIn(initialScale = 0.8f),
+        exit = fadeOut() + scaleOut(targetScale = 0.8f),
+        modifier = modifier,
+    ) {
+        when (geometry) {
+            QuickActionGeometry.RADIAL_ARC -> RadialArcActions(anchorEdgeIsStart, onSelect)
+            QuickActionGeometry.EDGE_RAIL -> EdgeRailActions(onSelect)
+        }
+    }
+}
+
+@Composable
+private fun RadialArcActions(anchorEdgeIsStart: Boolean, onSelect: (QuickAction) -> Unit) {
+    val radiusDp = 96.dp
+    Box(modifier = Modifier.size(radiusDp * 2)) {
+        val (startAngle, endAngle) = if (anchorEdgeIsStart) -60f to 60f else 120f to 240f
+        ACTIONS.forEachIndexed { index, (action, label) ->
+            val angleDeg = startAngle + index * (endAngle - startAngle) / (ACTIONS.size - 1)
+            val angleRad = Math.toRadians(angleDeg.toDouble())
+            val offsetX = (radiusDp.value * cos(angleRad)).dp
+            val offsetY = (radiusDp.value * sin(angleRad)).dp
+            QuickActionTarget(
+                label = label,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .offset(x = offsetX, y = offsetY)
+                    .clickable { onSelect(action) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun EdgeRailActions(onSelect: (QuickAction) -> Unit) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 4.dp,
+    ) {
+        Column {
+            ACTIONS.forEach { (action, label) ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp)
+                        .clickable { onSelect(action) }
+                        .padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(label, color = MaterialTheme.colorScheme.onSurface)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuickActionTarget(label: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.size(48.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primary,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(label.take(2), color = Color.White)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the phase-1 overlay interaction deliverables (`docs/phases/phase-1-character-interaction.md`), minus real Rive integration (no `.riv` asset exists yet — `CharacterPlaceholder` stands in, animated per `CharacterState`)
- Single resizable `WindowManager` overlay window driven by a state machine (collapsed bubble / long-press quick-actions / tap-to-expand panel), since fullscreen touch-passthrough needs the `@hide` `OnComputeInternalInsetsListener` API which isn't in the public SDK
- Drag-to-move with edge-snap, bottom-center dismiss zone, tap-to-expand 60%-height panel (collapses on background tap or swipe-down), long-press quick-actions implementing **both** geometries from the open design question (radial arc default, edge rail available via a persisted preference)
- `AppState`/`AppStateHolder`/`CharacterState` (`:core`) shared state, `OverlayPreferencesRepository` (`:core`) for DataStore-backed bubble position + geometry persistence
- Best-effort IME-visibility detection (bubble hides while another app's keyboard is open)
- Switched from hand-pinned `compose-ui`/`compose-material3` versions to the Compose BOM after hitting a real cross-artifact version-skew bug; bumped `compileSdk`/`targetSdk` to 37 (required by Compose 1.12.0)

## Bugs found and fixed via on-device testing (Moto G55)
- `ChampiService.onStartCommand` now also calls `overlayManager.show()` — previously only `onCreate` did, so relaunching after a dismiss never brought the bubble back
- Dismissing the bubble crashed the process silently: `onDismiss` called `hide()` (removing the view) synchronously from inside that same view's still-executing touch-gesture callback; deferred via `view.post(...)`
- Radial quick-actions arc used raw dp magnitudes as pixel offsets in `Modifier.offset { IntOffset(...) }`, rendering the arc ~2.5x smaller than intended and putting targets outside their tap area

## Test plan
- [x] `./gradlew :app:assembleDebug` succeeds
- [x] `./gradlew lint` passes with no errors
- [x] Manual on-device (Moto G55): drag + edge-snap, tap-to-expand + background-tap/swipe-down collapse, dismiss zone, relaunch restores bubble at last position, long-press radial-arc quick actions + selection (verified `SLEEP` updates `CharacterState` and bubble color), no crashes across all of the above
- [ ] Peek-after-idle and IME-avoidance are implemented but not exercised in this manual pass (long idle wait / real keyboard interaction needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFKVeMNAqsPXt4CrWdgao3