### PR TITLE
fix(overlay): close M1 gaps found against issues #9-#13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Expanded panel window never cleared `FLAG_NOT_FOCUSABLE`, so a future text-input row (issue #21) would never be able to receive keyboard focus; `WindowSpec` now carries a `focusable` bit, set for the expanded panel only
+- Peek idle timeout was a hardcoded 3-minute constant; now DataStore-backed (`peekMinutes`, default 5, 0 disables peek) and resets on any non-`IDLE` character state, not just gestures (issue #11)
+- `AppState` was missing the `attention`/`mood` fields the state-machine spec calls for (issue #9); added with setters on `AppStateHolder` — wiring `attention` to live finger position during quick-actions is left for a follow-up, since it needs the gesture detection restructured from discrete click targets to continuous drag hit-testing
+
 ### Added
 - Phase 1 character + interaction: single `WindowManager` overlay window that resizes/repositions per state (collapsed bubble / long-press quick-actions / tap-to-expand panel) — the standard "chat heads" technique, since fullscreen touch-passthrough would require the `@hide` `OnComputeInternalInsetsListener` API
 - Drag-to-move with edge-snap on release, and a bottom-center dismiss zone that hides the bubble until the app is relaunched (`OverlayRoot`, `:overlay`)

--- a/core/src/main/kotlin/ai/champi/core/overlay/OverlayPreferencesRepository.kt
+++ b/core/src/main/kotlin/ai/champi/core/overlay/OverlayPreferencesRepository.kt
@@ -49,10 +49,19 @@ class OverlayPreferencesRepository @Inject constructor(
         dataStore.edit { it[KEY_QUICK_ACTION_GEOMETRY] = geometry.name }
     }
 
+    /** Idle minutes before the bubble peeks under its snapped edge; 0 disables peek entirely. */
+    val peekMinutes: Flow<Int> = dataStore.data.map { prefs -> prefs[KEY_PEEK_MINUTES] ?: DEFAULT_PEEK_MINUTES }
+
+    suspend fun setPeekMinutes(minutes: Int) {
+        dataStore.edit { it[KEY_PEEK_MINUTES] = minutes }
+    }
+
     private companion object {
         val KEY_BUBBLE_X = intPreferencesKey("bubble_x")
         val KEY_BUBBLE_Y = intPreferencesKey("bubble_y")
         val KEY_QUICK_ACTION_GEOMETRY = stringPreferencesKey("quick_action_geometry")
+        val KEY_PEEK_MINUTES = intPreferencesKey("peek_minutes")
         const val DEFAULT_BUBBLE_Y = 600
+        const val DEFAULT_PEEK_MINUTES = 5
     }
 }

--- a/core/src/main/kotlin/ai/champi/core/state/AppState.kt
+++ b/core/src/main/kotlin/ai/champi/core/state/AppState.kt
@@ -10,4 +10,9 @@ data class AppState(
     val characterState: CharacterState = CharacterState.IDLE,
     val conversation: List<ConversationEntry> = emptyList(),
     val audioLevel: Float = 0f,
+    /** 0f..1f: how focused the character's gaze/pose should be, e.g. driven by finger position
+     * relative to the bubble during a long-press quick-actions interaction. */
+    val attention: Float = 0f,
+    /** 0f..1f: character mood/expression input for the Rive state machine (neutral = 0.5f). */
+    val mood: Float = 0.5f,
 )

--- a/core/src/main/kotlin/ai/champi/core/state/AppStateHolder.kt
+++ b/core/src/main/kotlin/ai/champi/core/state/AppStateHolder.kt
@@ -20,6 +20,14 @@ class AppStateHolder @Inject constructor() {
         _state.update { it.copy(audioLevel = level) }
     }
 
+    fun setAttention(attention: Float) {
+        _state.update { it.copy(attention = attention.coerceIn(0f, 1f)) }
+    }
+
+    fun setMood(mood: Float) {
+        _state.update { it.copy(mood = mood.coerceIn(0f, 1f)) }
+    }
+
     fun appendConversationEntry(entry: ConversationEntry) {
         _state.update { it.copy(conversation = it.conversation + entry) }
     }

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayManager.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayManager.kt
@@ -68,6 +68,11 @@ class OverlayManager @Inject constructor(
                     layoutParams.x = spec.xPx
                     layoutParams.y = spec.yPx
                     layoutParams.gravity = spec.gravity
+                    layoutParams.flags = if (spec.focusable) {
+                        layoutParams.flags and WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE.inv()
+                    } else {
+                        layoutParams.flags or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                    }
                     runCatching { windowManager.updateViewLayout(view, layoutParams) }
                 },
             )

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
@@ -44,7 +44,6 @@ import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
 private const val LONG_PRESS_TIMEOUT_MS = 400L
-private const val PEEK_IDLE_TIMEOUT_MS = 3 * 60 * 1000L
 private const val BUBBLE_SIZE_DP = 56
 private const val PEEK_VISIBLE_DP = 28
 // Radial arc: 96 dp radius + 48 dp button diameter means ~240 dp min; use 280 dp to avoid edge clipping
@@ -75,6 +74,7 @@ internal fun OverlayRoot(
     var peeked by remember { mutableStateOf(false) }
     var geometry by remember { mutableStateOf(QuickActionGeometry.RADIAL_ARC) }
     var imeVisible by remember { mutableStateOf(false) }
+    var peekMinutes by remember { mutableStateOf(5) }
 
     // configuration.screenHeightDp is the *raw* display height, but this window's y-coordinate
     // is relative to the status-bar-inset parent frame WindowManager gives it — clamping against
@@ -105,6 +105,9 @@ internal fun OverlayRoot(
     LaunchedEffect(Unit) {
         preferences.quickActionGeometry.collectLatest { geometry = it }
     }
+    LaunchedEffect(Unit) {
+        preferences.peekMinutes.collectLatest { peekMinutes = it }
+    }
 
     // Best-effort keyboard detection: this overlay window is FLAG_NOT_FOCUSABLE so it never
     // receives WindowInsets for another app's IME. Comparing the visible display frame is the
@@ -119,10 +122,15 @@ internal fun OverlayRoot(
         onDispose { view.viewTreeObserver.removeOnGlobalLayoutListener(listener) }
     }
 
-    LaunchedEffect(bubbleOffset, mode) {
+    // Resets on any gesture (bubbleOffset/mode change) and on any non-IDLE character state, per
+    // the peek spec — an in-progress conversation shouldn't have the bubble tuck itself away.
+    LaunchedEffect(bubbleOffset, mode, appState.characterState) {
         peeked = false
-        if (mode == OverlayMode.COLLAPSED) {
-            delay(PEEK_IDLE_TIMEOUT_MS)
+        if (mode == OverlayMode.COLLAPSED &&
+            appState.characterState == CharacterState.IDLE &&
+            peekMinutes > 0
+        ) {
+            delay(peekMinutes * 60_000L)
             peeked = true
         }
     }
@@ -135,6 +143,7 @@ internal fun OverlayRoot(
                 xPx = 0,
                 yPx = 0,
                 gravity = Gravity.BOTTOM or Gravity.START,
+                focusable = true,
             )
 
             OverlayMode.QUICK_ACTIONS -> {

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayWindow.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayWindow.kt
@@ -9,4 +9,8 @@ internal data class WindowSpec(
     val xPx: Int,
     val yPx: Int,
     val gravity: Int,
+    // FLAG_NOT_FOCUSABLE must be cleared while the expanded panel is open so a future text input
+    // row can receive the keyboard; every other mode stays unfocusable so the overlay never steals
+    // input focus from whatever app is running underneath.
+    val focusable: Boolean = false,
 )


### PR DESCRIPTION
## Summary
PR #65 delivered Phase 1 (M1) and its own description matched the phase doc, but comparing against the actual tracked issues (#9-#13) surfaced three real gaps beyond what that summary covered:

- **`FLAG_NOT_FOCUSABLE` was never cleared for the expanded panel** — a real blocker for issue #21 (conversation input row), since without this a text field in the panel could never receive keyboard focus. `WindowSpec` now carries a `focusable` bit (set for `EXPANDED` only); `OverlayManager` toggles the flag on window updates. Verified on-device: `NOT_FOCUSABLE` absent while expanded, restored on collapse, no crash.
- **Peek idle timeout was a hardcoded 3-minute constant** — issue #11 specifies a DataStore-backed `peekMinutes` (default 5, 0 disables peek), and that the idle timer reset on *any* non-`IDLE` character state, not just gestures (a bubble shouldn't tuck itself away mid-conversation). Both added.
- **`AppState` was missing `attention`/`mood`** — issue #9 specifies `level`/`attention`/`mood`; had `audioLevel` (equivalent to `level`) but not the other two. Added with setters on `AppStateHolder`.

Position-write debouncing (also called out in #10) turned out to already be satisfied by the existing design: `onDrag` only mutates in-memory state, `DataStore` is written once on release, not per-frame — no change needed.

**Deliberately deferred:** wiring `attention` to live finger position during the quick-actions long-press (#13's last acceptance criterion) needs the quick-actions gesture detection restructured from discrete per-target `clickable` handlers to continuous drag hit-testing against target bounds. That's a bigger, separable change — noted as a TODO rather than bundled in here.

## Test plan
- [x] `./gradlew :overlay:compileDebugKotlin` succeeds
- [x] `./gradlew :overlay:lint :core:lint` clean
- [x] Manual on-device (Moto G55): tapped bubble open → confirmed `NOT_FOCUSABLE` absent from window flags via `dumpsys window windows`; tapped background to collapse → confirmed `NOT_FOCUSABLE` restored; no crash, pid stable throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf2mGvRUbUc41ikUJxCHoY