### PR TITLE
feat(overlay): spring animation on bubble edge-snap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Spring animation on bubble edge-snap release (issue #10), instead of an instant jump
+
 ### Fixed
 - Expanded panel window never cleared `FLAG_NOT_FOCUSABLE`, so a future text-input row (issue #21) would never be able to receive keyboard focus; `WindowSpec` now carries a `focusable` bit, set for the expanded panel only
 - Peek idle timeout was a hardcoded 3-minute constant; now DataStore-backed (`peekMinutes`, default 5, 0 disables peek) and resets on any non-`IDLE` character state, not just gestures (issue #11)
 - `AppState` was missing the `attention`/`mood` fields the state-machine spec calls for (issue #9); added with setters on `AppStateHolder` — wiring `attention` to live finger position during quick-actions is left for a follow-up, since it needs the gesture detection restructured from discrete click targets to continuous drag hit-testing
+- The initial spring-animation attempt crashed the process: `Animatable.animateTo` needs a `MonotonicFrameClock`, only available on a coroutine scope tied to the Composition, not the plain `CoroutineScope` passed down from `OverlayManager`; now uses a `rememberCoroutineScope()`-backed scope for the animation specifically
 
 ### Added
 - Phase 1 character + interaction: single `WindowManager` overlay window that resizes/repositions per state (collapsed bubble / long-press quick-actions / tap-to-expand panel) — the standard "chat heads" technique, since fullscreen touch-passthrough would require the `@hide` `OnComputeInternalInsetsListener` API

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
@@ -10,6 +10,9 @@ import android.graphics.Rect as AndroidRect
 import android.os.SystemClock
 import android.view.Gravity
 import android.view.ViewTreeObserver
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,6 +26,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -68,6 +72,10 @@ internal fun OverlayRoot(
     val density = LocalDensity.current
     val view = LocalView.current
     val configuration = LocalConfiguration.current
+    // Animatable.animateTo needs a MonotonicFrameClock, which only exists on a coroutine scope
+    // tied to the Composition — the `scope` parameter (a plain CoroutineScope from OverlayManager)
+    // doesn't have one and crashes with IllegalStateException if used for animation.
+    val animationScope = rememberCoroutineScope()
 
     var mode by remember { mutableStateOf(OverlayMode.COLLAPSED) }
     var bubbleOffset by remember { mutableStateOf(IntOffset(0, 600)) }
@@ -229,8 +237,19 @@ internal fun OverlayRoot(
                                 onDismiss()
                             } else {
                                 val snappedX = if (centerX < screenWidthPx / 2) 0 else screenWidthPx - bubblePx
-                                bubbleOffset = bubbleOffset.copy(x = snappedX)
-                                scope.launch { preferences.saveBubbleOffset(BubbleOffset(snappedX, bubbleOffset.y)) }
+                                val snappedY = bubbleOffset.y
+                                scope.launch { preferences.saveBubbleOffset(BubbleOffset(snappedX, snappedY)) }
+                                animationScope.launch {
+                                    Animatable(bubbleOffset.x.toFloat()).animateTo(
+                                        targetValue = snappedX.toFloat(),
+                                        animationSpec = spring(
+                                            dampingRatio = Spring.DampingRatioMediumBouncy,
+                                            stiffness = Spring.StiffnessMedium,
+                                        ),
+                                    ) {
+                                        bubbleOffset = IntOffset(value.roundToInt(), snappedY)
+                                    }
+                                }
                             }
                         },
                         onTap = { mode = OverlayMode.EXPANDED },


### PR DESCRIPTION
## Summary
Issue #10's acceptance criteria calls for the bubble to snap to its edge "with a short spring animation" on release — it previously snapped instantly with no animation.

## A real crash found while building this
The first attempt used the `scope` parameter passed down from `OverlayManager` (a plain `CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)`, no ties to the Composition) to launch the `Animatable.animateTo` call. This throws `IllegalStateException: A MonotonicFrameClock is not available in this CoroutineContext` on **every** invocation — `Animatable` animations require a frame clock that's normally supplied by Compose's runtime, which only exists on a coroutine scope created via `rememberCoroutineScope()` inside the Composition.

On-device, this manifested as: drag the bubble, release near an edge → app silently dies and the foreground service restarts, losing whatever interaction was in progress, with the crash only visible in `adb logcat -b crash` (not the main buffer). Fixed by adding a `rememberCoroutineScope()`-backed `animationScope` used specifically for the animation, while keeping the original `scope` for the DataStore write (a plain suspend call — doesn't need a frame clock).

## Test plan
- [x] `./gradlew :overlay:compileDebugKotlin` succeeds
- [x] `./gradlew :overlay:lint` clean
- [x] Manual on-device (Moto G55): dragged bubble toward center, released — bubble springs smoothly to the nearest edge, no crash (`pid` stable, `adb logcat -b crash` empty)
- [x] Restarted the app after the snap — bubble restores at the snapped position (persistence still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf2mGvRUbUc41ikUJxCHoY