### PR TITLE
feat(app): settings screen for quick-actions geometry and peek timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Spring animation on bubble edge-snap release (issue #10), instead of an instant jump
+- `SettingsActivity` (`:app`) — wires the quick-actions Settings target to a real screen: quick-actions geometry (radial arc / edge rail) and peek idle timeout (0-15 min, 0 disables peek), both backed by `OverlayPreferencesRepository`
 
 ### Fixed
+- Launching `SettingsActivity` via an implicit intent (custom action + manifest intent-filter) threw `ActivityNotFoundException` despite the filter being correctly registered — apps targeting API 31+ can't resolve implicit intents to a non-exported activity, even within the same app; switched to an explicit intent via `Intent.setClassName`
 - Expanded panel window never cleared `FLAG_NOT_FOCUSABLE`, so a future text-input row (issue #21) would never be able to receive keyboard focus; `WindowSpec` now carries a `focusable` bit, set for the expanded panel only
 - Peek idle timeout was a hardcoded 3-minute constant; now DataStore-backed (`peekMinutes`, default 5, 0 disables peek) and resets on any non-`IDLE` character state, not just gestures (issue #11)
 - `AppState` was missing the `attention`/`mood` fields the state-machine spec calls for (issue #9); added with setters on `AppStateHolder` — wiring `attention` to live finger position during quick-actions is left for a follow-up, since it needs the gesture detection restructured from discrete click targets to continuous drag hit-testing

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,14 @@
             </intent-filter>
         </activity>
 
+        <!-- Launched via an explicit Intent.setClassName from :overlay (see
+             ai.champi.core.overlay.SETTINGS_ACTIVITY_CLASS), not an intent-filter — apps
+             targeting API 31+ can't resolve implicit intents to a non-exported activity, even
+             within the same app. -->
+        <activity
+            android:name=".SettingsActivity"
+            android:exported="false" />
+
         <service
             android:name=".ChampiService"
             android:exported="false"

--- a/app/src/main/kotlin/ai/champi/app/SettingsActivity.kt
+++ b/app/src/main/kotlin/ai/champi/app/SettingsActivity.kt
@@ -1,0 +1,115 @@
+package ai.champi.app
+
+import ai.champi.core.overlay.OverlayPreferencesRepository
+import ai.champi.core.overlay.QuickActionGeometry
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Plain (non-overlay) settings screen, launched from the quick-actions Settings target via an
+ * explicit intent naming [ai.champi.core.overlay.SETTINGS_ACTIVITY_CLASS]. Phase 1: just the two
+ * persisted overlay preferences that exist so far — quick-actions geometry and peek idle timeout.
+ */
+@AndroidEntryPoint
+class SettingsActivity : ComponentActivity() {
+
+    @Inject lateinit var preferences: OverlayPreferencesRepository
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    SettingsScreen(preferences)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsScreen(preferences: OverlayPreferencesRepository) {
+    val scope = rememberCoroutineScope()
+    val geometry by preferences.quickActionGeometry.collectAsState(initial = QuickActionGeometry.RADIAL_ARC)
+    val peekMinutes by preferences.peekMinutes.collectAsState(initial = 5)
+
+    Column(modifier = Modifier.fillMaxSize().padding(24.dp)) {
+        Text("Settings", style = MaterialTheme.typography.headlineSmall)
+
+        Text(
+            "Quick-actions layout",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(top = 24.dp),
+        )
+        Column(modifier = Modifier.selectableGroup().padding(top = 8.dp)) {
+            QuickActionGeometry.entries.forEach { option ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = geometry == option,
+                            onClick = { scope.launch { preferences.setQuickActionGeometry(option) } },
+                            role = Role.RadioButton,
+                        )
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(selected = geometry == option, onClick = null)
+                    Text(
+                        when (option) {
+                            QuickActionGeometry.RADIAL_ARC -> "Radial arc"
+                            QuickActionGeometry.EDGE_RAIL -> "Edge rail"
+                        },
+                        modifier = Modifier.padding(start = 12.dp),
+                    )
+                }
+            }
+        }
+
+        Text(
+            "Bubble peek",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(top = 24.dp),
+        )
+        Text(
+            if (peekMinutes == 0) {
+                "Disabled — the bubble stays fully visible"
+            } else {
+                "Tucks under the edge after $peekMinutes ${if (peekMinutes == 1) "minute" else "minutes"} idle"
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+        Slider(
+            value = peekMinutes.toFloat(),
+            onValueChange = { scope.launch { preferences.setPeekMinutes(it.toInt()) } },
+            valueRange = 0f..15f,
+            steps = 14,
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        )
+    }
+}

--- a/core/src/main/kotlin/ai/champi/core/overlay/QuickAction.kt
+++ b/core/src/main/kotlin/ai/champi/core/overlay/QuickAction.kt
@@ -13,3 +13,13 @@ enum class QuickActionGeometry {
     RADIAL_ARC,
     EDGE_RAIL,
 }
+
+/**
+ * `:app`'s `SettingsActivity`, referenced by fully-qualified class name (via
+ * `Intent.setClassName`) rather than a compile-time dependency, since `:overlay` doesn't (and
+ * shouldn't) depend on `:app`. Must be an *explicit* intent, not an action-based implicit one:
+ * apps targeting API 31+ can't resolve implicit intents to a non-exported activity, even within
+ * the same app — confirmed on-device (`ActivityNotFoundException` despite the manifest filter
+ * being correctly registered) before switching to this.
+ */
+const val SETTINGS_ACTIVITY_CLASS = "ai.champi.app.SettingsActivity"

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
@@ -4,8 +4,10 @@ import ai.champi.core.overlay.BubbleOffset
 import ai.champi.core.overlay.OverlayPreferencesRepository
 import ai.champi.core.overlay.QuickAction
 import ai.champi.core.overlay.QuickActionGeometry
+import ai.champi.core.overlay.SETTINGS_ACTIVITY_CLASS
 import ai.champi.core.state.AppStateHolder
 import ai.champi.core.state.CharacterState
+import android.content.Intent
 import android.graphics.Rect as AndroidRect
 import android.os.SystemClock
 import android.view.Gravity
@@ -205,7 +207,15 @@ internal fun OverlayRoot(
                 anchorEdgeIsStart = isAtStartEdge,
                 onSelect = { action ->
                     mode = OverlayMode.COLLAPSED
-                    if (action == QuickAction.SLEEP) appStateHolder.setCharacterState(CharacterState.SLEEPING)
+                    when (action) {
+                        QuickAction.SLEEP -> appStateHolder.setCharacterState(CharacterState.SLEEPING)
+                        QuickAction.SETTINGS -> view.context.startActivity(
+                            Intent()
+                                .setClassName(view.context.packageName, SETTINGS_ACTIVITY_CLASS)
+                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                        )
+                        QuickAction.MUTE_MIC, QuickAction.PUSH_TO_TALK -> Unit // stubs until :audio lands
+                    }
                 },
                 modifier = Modifier.align(Alignment.Center),
             )


### PR DESCRIPTION
## Summary
Wires the quick-actions Settings target (previously a no-op stub) to a real screen: radio buttons for quick-actions geometry (radial arc / edge rail) and a slider for the peek idle timeout (0–15 min, 0 = disabled), both backed by the existing `OverlayPreferencesRepository` DataStore.

## A real crash found along the way
The first attempt launched `SettingsActivity` via an implicit intent — a custom action string matched by an intent-filter declared in the manifest. This threw `ActivityNotFoundException` despite the filter being correctly registered (confirmed with `dumpsys package ai.champi.app`, which showed the filter present). Root cause: apps targeting API 31+ can't resolve implicit intents to a **non-exported** activity, even within the same app/UID — a security hardening that's easy to miss since same-app resolution "should" work by the old rules.

Fixed by switching to an explicit intent via `Intent.setClassName`, which isn't subject to that restriction. `:overlay` references `:app`'s `SettingsActivity` by fully-qualified class name string rather than a compile-time dependency (the module dependency graph only goes the other way — `:app` depends on `:overlay`, not vice versa).

## Test plan
- [x] `./gradlew :app:compileDebugKotlin :overlay:compileDebugKotlin` succeeds
- [x] `./gradlew :app:lint :overlay:lint :core:lint` clean
- [x] Manual on-device (Moto G55): long-pressed bubble → tapped Settings target → screen opened cleanly without switching away from the home screen underneath; toggled to Edge rail, returned to overlay, long-pressed again — edge-rail geometry rendered immediately, confirming the DataStore round-trip; re-opened Settings a second time to confirm no state corruption; no crashes throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf2mGvRUbUc41ikUJxCHoY