### PR TITLE
fix(app,overlay): notification-permission gating and TalkBack accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Spring animation on bubble edge-snap release (issue #10), instead of an instant jump
 - `SettingsActivity` (`:app`) — wires the quick-actions Settings target to a real screen: quick-actions geometry (radial arc / edge rail) and peek idle timeout (0-15 min, 0 disables peek), both backed by `OverlayPreferencesRepository`
+- Partial TalkBack accessibility (issue #58, remainder blocked on #31/#44 which don't exist yet): bubble now has `contentDescription` plus semantic click/long-click actions mirroring its custom gesture detector, which was otherwise invisible to TalkBack; expanded panel gained a real 48dp "Close panel" button (replacing a 32x4dp non-focusable decorative bar); Settings screen's peek-timeout slider gained a `contentDescription`
 
 ### Fixed
 - Launching `SettingsActivity` via an implicit intent (custom action + manifest intent-filter) threw `ActivityNotFoundException` despite the filter being correctly registered — apps targeting API 31+ can't resolve implicit intents to a non-exported activity, even within the same app; switched to an explicit intent via `Intent.setClassName`
+- `MainActivity` required both overlay and notification permission before starting `ChampiService`, contradicting the spec: denying `POST_NOTIFICATIONS` should omit the visible notification, not block the service from running at all; gated on overlay permission alone
+- Expanded panel's collapse-on-tap gesture wrapped the entire content `Column` in `.clickable`, which merges all non-interactive descendant semantics into one TalkBack node — harmless today but a trap for issue #21's future input row; moved onto a dedicated background layer instead
 - Expanded panel window never cleared `FLAG_NOT_FOCUSABLE`, so a future text-input row (issue #21) would never be able to receive keyboard focus; `WindowSpec` now carries a `focusable` bit, set for the expanded panel only
 - Peek idle timeout was a hardcoded 3-minute constant; now DataStore-backed (`peekMinutes`, default 5, 0 disables peek) and resets on any non-`IDLE` character state, not just gestures (issue #11)
 - `AppState` was missing the `attention`/`mood` fields the state-machine spec calls for (issue #9); added with setters on `AppStateHolder` — wiring `attention` to live finger position during quick-actions is left for a follow-up, since it needs the gesture detection restructured from discrete click targets to continuous drag hit-testing

--- a/app/src/main/kotlin/ai/champi/app/MainActivity.kt
+++ b/app/src/main/kotlin/ai/champi/app/MainActivity.kt
@@ -73,8 +73,10 @@ private fun PermissionScreen(onAllGranted: () -> Unit) {
         ActivityResultContracts.RequestPermission(),
     ) { granted -> notifGranted = granted }
 
-    LaunchedEffect(overlayGranted, notifGranted) {
-        if (overlayGranted && notifGranted) onAllGranted()
+    // Notification permission only controls whether the foreground-service notification is
+    // visible, not whether the service can run at all — so it's requested but not required.
+    LaunchedEffect(overlayGranted) {
+        if (overlayGranted) onAllGranted()
     }
 
     Column(
@@ -101,7 +103,7 @@ private fun PermissionScreen(onAllGranted: () -> Unit) {
             }
         }
 
-        if (overlayGranted && notifGranted) {
+        if (overlayGranted) {
             Text("All set — Champi is running.")
         }
     }

--- a/app/src/main/kotlin/ai/champi/app/SettingsActivity.kt
+++ b/app/src/main/kotlin/ai/champi/app/SettingsActivity.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -109,7 +111,10 @@ private fun SettingsScreen(preferences: OverlayPreferencesRepository) {
             onValueChange = { scope.launch { preferences.setPeekMinutes(it.toInt()) } },
             valueRange = 0f..15f,
             steps = 14,
-            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp)
+                .semantics { contentDescription = "Bubble peek idle timeout in minutes, 0 disables" },
         )
     }
 }

--- a/overlay/src/main/kotlin/ai/champi/overlay/ExpandedPanel.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/ExpandedPanel.kt
@@ -18,6 +18,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 
 private const val SWIPE_DOWN_DISMISS_THRESHOLD_DP = 48
@@ -33,55 +36,82 @@ fun ExpandedPanel(appState: AppState, onCollapse: () -> Unit, modifier: Modifier
     val dismissThresholdPx = with(density) { SWIPE_DOWN_DISMISS_THRESHOLD_DP.dp.toPx() }
 
     Surface(
-        modifier = modifier
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-            ) { onCollapse() }
-            .pointerInput(Unit) {
-                var totalDragY = 0f
-                detectVerticalDragGestures(
-                    onDragStart = { totalDragY = 0f },
-                    onDragEnd = { if (totalDragY > dismissThresholdPx) onCollapse() },
-                ) { change, dragAmount ->
-                    change.consume()
-                    totalDragY += dragAmount
-                }
-            },
+        modifier = modifier,
         shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 8.dp,
     ) {
-        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            // Background layer for the tap/swipe-to-collapse convenience gesture, sitting behind
+            // the real content below. Keeping this a separate layer (rather than wrapping the
+            // whole Column in .clickable, as before) matters once #21 adds real interactive
+            // controls in here: an ancestor .clickable merges all *non-interactive* descendant
+            // semantics into one giant TalkBack node, which would swallow plain Text/Icon content
+            // even though a genuinely interactive descendant survives the merge — better not to
+            // rely on that distinction at all. Excluded from the semantics tree since the
+            // dedicated "Close panel" handle below already exposes an accessible equivalent.
             Box(
                 modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .size(width = 32.dp, height = 4.dp)
-                    .background(MaterialTheme.colorScheme.onSurfaceVariant, CircleShape),
+                    .fillMaxSize()
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) { onCollapse() }
+                    .pointerInput(Unit) {
+                        var totalDragY = 0f
+                        detectVerticalDragGestures(
+                            onDragStart = { totalDragY = 0f },
+                            onDragEnd = { if (totalDragY > dismissThresholdPx) onCollapse() },
+                        ) { change, dragAmount ->
+                            change.consume()
+                            totalDragY += dragAmount
+                        }
+                    }
+                    .clearAndSetSemantics {},
             )
-            Spacer(Modifier.height(12.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                CharacterPlaceholder(state = appState.characterState, size = 96.dp)
-                Text("Champi", style = MaterialTheme.typography.titleMedium)
-            }
-            Spacer(Modifier.height(16.dp))
-            if (appState.conversation.isEmpty()) {
+
+            Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
                 Box(
-                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .size(48.dp)
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                        ) { onCollapse() }
+                        .semantics { contentDescription = "Close panel" },
                     contentAlignment = Alignment.Center,
                 ) {
-                    Text(
-                        "No conversation yet.",
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    Box(
+                        modifier = Modifier
+                            .size(width = 32.dp, height = 4.dp)
+                            .background(MaterialTheme.colorScheme.onSurfaceVariant, CircleShape),
                     )
                 }
-            } else {
-                LazyColumn(modifier = Modifier.weight(1f)) {
-                    items(appState.conversation) { entry -> Text(entry.text) }
+                Spacer(Modifier.height(12.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CharacterPlaceholder(state = appState.characterState, size = 96.dp)
+                    Text("Champi", style = MaterialTheme.typography.titleMedium)
+                }
+                Spacer(Modifier.height(16.dp))
+                if (appState.conversation.isEmpty()) {
+                    Box(
+                        modifier = Modifier.weight(1f).fillMaxWidth(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            "No conversation yet.",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                } else {
+                    LazyColumn(modifier = Modifier.weight(1f)) {
+                        items(appState.conversation) { entry -> Text(entry.text) }
+                    }
                 }
             }
         }

--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayRoot.kt
@@ -41,6 +41,10 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.onLongClick
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
@@ -227,6 +231,22 @@ internal fun OverlayRoot(
         OverlayMode.COLLAPSED -> Box(
             modifier = Modifier
                 .size(BUBBLE_SIZE_DP.dp)
+                // TalkBack synthesizes double-tap/two-finger-double-tap into semantics click
+                // actions rather than replaying raw touch events, so the custom gesture detector
+                // below (needed to disambiguate tap/drag/long-press on one pointer stream) is
+                // invisible to it without these — without this block, TalkBack could describe the
+                // bubble but never actually activate it.
+                .semantics {
+                    contentDescription = "Champi assistant"
+                    onClick(label = "Open conversation") {
+                        mode = OverlayMode.EXPANDED
+                        true
+                    }
+                    onLongClick(label = "Open quick actions") {
+                        mode = OverlayMode.QUICK_ACTIONS
+                        true
+                    }
+                }
                 .pointerInput(Unit) {
                     detectBubbleGestures(
                         onTouchStart = { peeked = false },


### PR DESCRIPTION
## Summary
Two threads closed out issues #5-#8 (M0, confirmed stale/complete) surfaced against:

**Permission gating (issue #8):** `MainActivity` required both overlay *and* notification permission before starting `ChampiService`, contradicting the spec — denying `POST_NOTIFICATIONS` should omit the visible notification, not block the service from starting at all. `startForeground()` doesn't need the permission to succeed, only the notification's actual visibility depends on it. Gated on overlay permission alone now.

**TalkBack accessibility (issue #58, partial — full completion blocked on #31/#44 which don't exist yet):**
- The bubble's custom `pointerInput` gesture detector (needed to disambiguate tap/drag/long-press on one pointer stream) was invisible to TalkBack, which synthesizes double-tap into semantics click actions rather than replaying raw touch events. Added `contentDescription` + `onClick`/`onLongClick` semantics actions mirroring the existing handlers — without this, TalkBack could describe the bubble but never activate it.
- The expanded panel's collapse gesture wrapped the entire content `Column` in `.clickable`, which merges all non-interactive descendant semantics (Text, Icon) into one TalkBack node. Harmless today (no other interactive children exist yet) but a trap for #21's future input row. Restructured onto a background layer (excluded from the semantics tree, now a touch-convenience duplicate) plus a real 48dp "Close panel" button — the previous drag handle was a 32×4dp decorative bar, under the a11y minimum touch target and not focusable at all.
- Settings screen's peek-timeout `Slider` gained a `contentDescription`.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin :overlay:compileDebugKotlin` succeeds
- [x] `./gradlew :app:lint :overlay:lint` clean
- [x] Manual on-device (Moto G55): tap-to-expand and handle-tap-to-collapse both verified working through the panel restructuring; no crashes (`adb logcat -b crash` empty throughout)
- [ ] Full TalkBack pass (enable TalkBack, verify announcements/double-tap-activation) not yet run — the structural semantics are in place but haven't been walked with the actual screen reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf2mGvRUbUc41ikUJxCHoY