### PR TITLE
fix(ci): switch CodeQL to a manual build, fixing a silent failure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "20 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        with:
+          languages: java-kotlin
+          build-mode: manual
+
+      # The default "autobuild" CodeQL setup can't reliably trigger the Kotlin extractor across
+      # this project's multi-module Gradle build (confirmed failing on every PR this session with
+      # "CodeQL could not process any code written in Java/Kotlin") — building explicitly here
+      # instead, the same way android-ci.yml does, fixes that.
+      - name: Build
+        run: ./gradlew assembleDebug
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        with:
+          category: "/language:java-kotlin"


### PR DESCRIPTION
## Summary
The "Analyze (java-kotlin)" check has been failing on every PR since at least #67, without blocking merges since it isn't a required status check — easy to miss unless you look past the `build` job specifically.

Root cause: the repo's CodeQL "default setup" (configured at Settings → Code security, no workflow file in the repo — confirmed via `gh api repos/.../code-scanning/default-setup`) uses `autobuild`, which can't reliably trigger the Kotlin extractor across this project's multi-module Gradle build. Every run fails at the finalize step with:
```
CodeQL could not process any code written in Java/Kotlin. For more information, review our
troubleshooting guide at https://gh.io/troubleshooting-code-scanning/no-source-code-seen-during-build.
```

## Fix
Adds an explicit `.github/workflows/codeql.yml` with `build-mode: manual`, running the same `./gradlew assembleDebug` `android-ci.yml` already uses — the standard fix for this class of CodeQL/Gradle-Kotlin issue. Presence of this workflow file supersedes the repo's default CodeQL setup.

## Test plan
- [x] Confirmed via `gh pr checks` that this exact failure recurred on #67, #69, #70 (all merged despite it)
- [ ] This PR's own CI run should show the new workflow succeeding — will check once triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf2mGvRUbUc41ikUJxCHoY