### PR TITLE
fix(assistant): reconcile TurnOrchestrator after three-way merge

### DIFF
--- a/assistant/src/androidTest/kotlin/ai/champi/assistant/QueueReplayWorkerTest.kt
+++ b/assistant/src/androidTest/kotlin/ai/champi/assistant/QueueReplayWorkerTest.kt
@@ -80,7 +80,7 @@ class QueueReplayWorkerTest {
             routingDecisionDao = db.routingDecisionDao(),
             routingSettingsRepository = settings,
         )
-        return TurnOrchestrator(conversationManager, routingPolicy, settings, queuedTurnDao, appStateHolder, emptyList())
+        return TurnOrchestrator(conversationManager, routingPolicy, settings, queuedTurnDao, appStateHolder, emptyList(), NoOpContextSnapshotSource)
     }
 
     /** Enqueues a turn with a given [inputText] and [messageCountAtEnqueue]. */
@@ -102,7 +102,7 @@ class QueueReplayWorkerTest {
         enqueue("second", enqueuedAt = 2_000L)
         enqueue("third", enqueuedAt = 3_000L)
 
-        val recordingOrchestrator = object : TurnOrchestrator(conversationManager, buildRoutingPolicy(), settings, queuedTurnDao, appStateHolder, emptyList()) {
+        val recordingOrchestrator = object : TurnOrchestrator(conversationManager, buildRoutingPolicy(), settings, queuedTurnDao, appStateHolder, emptyList(), NoOpContextSnapshotSource) {
             override suspend fun submitText(input: String) {
                 replayedInputs.add(input)
             }
@@ -123,7 +123,7 @@ class QueueReplayWorkerTest {
         // Add 11 messages to the conversation so the threshold (>10) is exceeded.
         repeat(11) { conversationManager.appendUserMessage("filler $it") }
 
-        val recordingOrchestrator = object : TurnOrchestrator(conversationManager, buildRoutingPolicy(), settings, queuedTurnDao, appStateHolder, emptyList()) {
+        val recordingOrchestrator = object : TurnOrchestrator(conversationManager, buildRoutingPolicy(), settings, queuedTurnDao, appStateHolder, emptyList(), NoOpContextSnapshotSource) {
             override suspend fun submitText(input: String) {
                 replayedInputs.add(input)
             }
@@ -144,7 +144,7 @@ class QueueReplayWorkerTest {
         enqueue("fresh question", messageCountAtEnqueue = 0)
         repeat(5) { conversationManager.appendUserMessage("filler $it") }
 
-        val recordingOrchestrator = object : TurnOrchestrator(conversationManager, buildRoutingPolicy(), settings, queuedTurnDao, appStateHolder, emptyList()) {
+        val recordingOrchestrator = object : TurnOrchestrator(conversationManager, buildRoutingPolicy(), settings, queuedTurnDao, appStateHolder, emptyList(), NoOpContextSnapshotSource) {
             override suspend fun submitText(input: String) {
                 replayedInputs.add(input)
             }
@@ -160,7 +160,7 @@ class QueueReplayWorkerTest {
     fun noAvailableProvider_doesNotDrainQueue() = runBlocking {
         enqueue("waiting")
 
-        val recordingOrchestrator = object : TurnOrchestrator(conversationManager, buildRoutingPolicy(available = false), settings, queuedTurnDao, appStateHolder, emptyList()) {
+        val recordingOrchestrator = object : TurnOrchestrator(conversationManager, buildRoutingPolicy(available = false), settings, queuedTurnDao, appStateHolder, emptyList(), NoOpContextSnapshotSource) {
             override suspend fun submitText(input: String) {
                 replayedInputs.add(input)
             }

--- a/assistant/src/androidTest/kotlin/ai/champi/assistant/TurnOrchestratorTest.kt
+++ b/assistant/src/androidTest/kotlin/ai/champi/assistant/TurnOrchestratorTest.kt
@@ -75,6 +75,7 @@ class TurnOrchestratorTest {
             queuedTurnDao,
             appStateHolder,
             actionProviders,
+            NoOpContextSnapshotSource,
         )
     }
 

--- a/assistant/src/main/kotlin/ai/champi/assistant/TurnOrchestrator.kt
+++ b/assistant/src/main/kotlin/ai/champi/assistant/TurnOrchestrator.kt
@@ -61,6 +61,7 @@ open class TurnOrchestrator @Inject constructor(
     private val queuedTurnDao: QueuedTurnDao,
     private val appStateHolder: AppStateHolder,
     private val actionProviders: List<ActionProvider>,
+    private val contextSnapshotSource: ContextSnapshotSource,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var activeTurn: Job? = null
@@ -108,8 +109,15 @@ open class TurnOrchestrator @Inject constructor(
         appStateHolder.appendConversationEntry(ConversationEntry(id = UUID.randomUUID().toString(), text = input, fromUser = true))
         conversationManager.appendUserMessage(input)
 
+        // Fetch the raw message history and this turn's ephemeral context-signal system message
+        // (if any signal is enabled) once, so routing and windowing see the same input.
+        val messages = conversationManager.messages.first()
+        val contextMessage = contextSnapshotSource.readSnapshot().toSystemMessage()
+        if (contextMessage != null) Log.d(TAG, "Context system message: ${contextMessage.content}")
+        val messagesWithContext = if (contextMessage != null) messages + contextMessage else messages
+
         // Unwindowed context for the routing heuristic — RoutingPolicy.fits() needs total tokens.
-        val routingCtx = buildConversationContext()
+        val routingCtx = Conversation(messagesWithContext.map { it.toConversationTurn() })
         val edgeOnly = routingSettingsRepository.edgeOnlyMode.first()
 
         val llmProvider = try {
@@ -135,15 +143,17 @@ open class TurnOrchestrator @Inject constructor(
 
         appStateHolder.setCharacterState(CharacterState.THINKING)
 
-        // Windowed context for the actual provider call, trimmed to the selected provider's budget.
-        val windowedCtx = buildWindowedContext(llmProvider.capabilities.maxInputTokens)
+        // Windowed context for the actual provider call, trimmed to the selected provider's
+        // budget. The context-signal message (if any) is a SYSTEM turn, so ContextWindowBuilder's
+        // always-include-system-messages rule keeps it in regardless of trimming.
+        val windowedCtx = ContextWindowBuilder.build(messagesWithContext, llmProvider.capabilities.maxInputTokens)
 
         val entryId = UUID.randomUUID().toString()
         var accumulated = ""
         var entryAppended = false
 
         try {
-            llmProvider.complete(ctx, tools = allToolSpecs).collect { event ->
+            llmProvider.complete(windowedCtx, tools = allToolSpecs).collect { event ->
                 when (event) {
                     is LlmEvent.Token -> {
                         accumulated += event.text
@@ -219,30 +229,6 @@ open class TurnOrchestrator @Inject constructor(
         }
 
         return provider.invoke(call)
-    }
-
-    private suspend fun buildConversationContext(): Conversation {
-        val turns = conversationManager.messages.first().map { it.toConversationTurn() }.toMutableList()
-
-        // Read a fresh context snapshot for this turn. If any signal is enabled and the
-        // corresponding permission is granted, a system message is prepended to the conversation.
-        // This is an ephemeral prepend — it is NOT persisted to ConversationEntity.
-        val contextMessage = contextSnapshotSource.readSnapshot().toSystemMessage()
-        if (contextMessage != null) {
-            Log.d(TAG, "Context system message: ${contextMessage.content}")
-            turns.add(0, contextMessage.toConversationTurn())
-        }
-
-        return Conversation(turns)
-    }
-
-    /**
-     * Builds a context-windowed [Conversation] for the actual provider call, trimmed to fit
-     * within [maxInputTokens] via [ContextWindowBuilder].
-     */
-    private suspend fun buildWindowedContext(maxInputTokens: Int): Conversation {
-        val messages = conversationManager.messages.first()
-        return ContextWindowBuilder.build(messages, maxInputTokens)
     }
 
     private companion object {

--- a/assistant/src/main/kotlin/ai/champi/assistant/di/AssistantModule.kt
+++ b/assistant/src/main/kotlin/ai/champi/assistant/di/AssistantModule.kt
@@ -4,6 +4,7 @@ import ai.champi.actions.AlarmTimerActionProvider
 import ai.champi.actions.CalendarActionProvider
 import ai.champi.assistant.RoutingPolicy
 import ai.champi.assistant.TurnOrchestrator
+import ai.champi.core.context.ContextSnapshotSource
 import ai.champi.core.persistence.QueuedTurnDao
 import ai.champi.core.persistence.RoutingDecisionDao
 import ai.champi.core.routing.RoutingSettingsRepository
@@ -67,6 +68,7 @@ object AssistantModule {
         queuedTurnDao: QueuedTurnDao,
         appStateHolder: AppStateHolder,
         actionProviders: @JvmSuppressWildcards List<ActionProvider>,
+        contextSnapshotSource: ContextSnapshotSource,
     ): TurnOrchestrator = TurnOrchestrator(
         conversationManager = conversationManager,
         routingPolicy = routingPolicy,
@@ -74,5 +76,6 @@ object AssistantModule {
         queuedTurnDao = queuedTurnDao,
         appStateHolder = appStateHolder,
         actionProviders = actionProviders,
+        contextSnapshotSource = contextSnapshotSource,
     )
 }


### PR DESCRIPTION
## Summary
Main was broken after PRs #95, #97, and #98 merged in sequence — each modified `TurnOrchestrator` independently without textual conflicts, but the combined result didn't compile:

- #98's tool-call rewrite referenced an undefined `ctx` where #95's windowed-context variable should have been used
- #97's `contextSnapshotSource` field was referenced but never added to the constructor or `AssistantModule`'s explicit provider

Beyond the compile errors, #47's context-signal system message was being computed for the routing heuristic (`RoutingPolicy.fits()`) but never actually forwarded to the windowed context passed to the LLM — the two are now built from the same message list plus context message, computed once per turn, so routing and the actual model call stay consistent.

## Test plan
- [x] `./gradlew assembleDebug lint` — BUILD SUCCESSFUL
- [x] Updated `TurnOrchestratorTest`/`QueueReplayWorkerTest` call sites for the new constructor parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)