### PR TITLE
fix(overlay): disable window resize animation blocking quick-actions

### DIFF
--- a/overlay/src/main/kotlin/ai/champi/overlay/OverlayManager.kt
+++ b/overlay/src/main/kotlin/ai/champi/overlay/OverlayManager.kt
@@ -64,6 +64,7 @@ class OverlayManager @Inject constructor(
             // FLAG_NOT_FOCUSABLE) — shrinks the window so the input row stays above the IME
             // instead of being covered by it.
             softInputMode = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+            disableMoveAnimation()
         }
 
         val view = ComposeView(context)
@@ -110,5 +111,26 @@ class OverlayManager @Inject constructor(
         composeView = null
         lifecycleOwner = null
         scope = null
+    }
+}
+
+/**
+ * Sets the hidden `WindowManager.LayoutParams.PRIVATE_FLAG_NO_MOVE_ANIMATION` bit (0x40) via
+ * reflection. Without it, WindowManagerService plays its default resize/reveal animation on every
+ * [WindowManager.updateViewLayout] bounds change for a [WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY]
+ * window — confirmed on-device (SurfaceFlinger logs an `animation-leash of window_animation` on
+ * every collapsed↔quick-actions resize) to take roughly a full second to settle, during which the
+ * quick-actions targets are effectively invisible. A normal-length long-press-and-release never
+ * survives that long, so the surface reads as "never opens." This flag is the standard fix used by
+ * floating-bubble ("chat heads"-style) overlays for exactly this issue; it's a plain non-final
+ * `int` field carrying `@UnsupportedAppUsage` rather than an enforced hidden API, so reflection
+ * access is expected to keep working, but this is still best-effort — failure just falls back to
+ * the (slow but functional) default animated resize rather than crashing.
+ */
+private fun WindowManager.LayoutParams.disableMoveAnimation() {
+    runCatching {
+        val field = WindowManager.LayoutParams::class.java.getField("privateFlags")
+        val noMoveAnimation = WindowManager.LayoutParams::class.java.getField("PRIVATE_FLAG_NO_MOVE_ANIMATION").getInt(null)
+        field.setInt(this, field.getInt(this) or noMoveAnimation)
     }
 }


### PR DESCRIPTION
## Summary
Long-pressing the bubble to open the radial/edge quick-actions surface appeared broken — the buttons never seemed to open.

On-device diagnosis (`adb dumpsys window` + SurfaceFlinger logs while holding the bubble) confirmed:
- The overlay window *does* resize correctly (140×140 → 700×700) the moment the long-press fires (~400ms), matching the code's intended behavior.
- But WindowManagerService plays its default resize/reveal animation on every `updateViewLayout()` bounds change for a `TYPE_APPLICATION_OVERLAY` window — visible in logs as `SurfaceFlinger: onHandleDestroyed: ... animation-leash of window_animation`.
- That animation takes roughly a full second to settle. A normal-length long-press-and-release never survives that long, so the quick-actions targets were effectively invisible for the whole interaction.

## Fix
Set the hidden `WindowManager.LayoutParams.PRIVATE_FLAG_NO_MOVE_ANIMATION` bit via reflection when the overlay window is created. This is the standard, widely-used fix for this exact issue in floating-bubble ("chat heads"-style) overlay apps. It's a plain non-final `int` field carrying `@UnsupportedAppUsage` rather than an enforced hidden API, so reflection access is expected to keep working; failure is caught and falls back silently to the previous (slow but functional) animated resize rather than crashing.

## Verification
Confirmed via `adb shell input touchscreen swipe` (simulated long-press) + `dumpsys window` + screenshots that, prior to the fix, the buttons only became visible ~1s+ into the hold. The current wireless adb bridge degraded significantly mid-session (screencap round-trips went from sub-second to ~160s), which made re-confirming exact post-fix timing over that connection impractical — the fix is applied and builds cleanly, but final on-device confirmation of the corrected timing should be done directly by the project owner.

## Test plan
- [x] `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL
- [ ] Manual on-device verification: long-press-and-release the bubble at a normal pace and confirm the quick-actions buttons are visible and tappable well within that window

🤖 Generated with [Claude Code](https://claude.com/claude-code)